### PR TITLE
Expose Encoder.EncodeSliceLen to mirror Decoder.DecodeSliceLen

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -53,7 +53,7 @@ func (e *Encoder) EncodeBytes(v []byte) error {
 	return e.write(v)
 }
 
-func (e *Encoder) encodeSliceLen(l int) error {
+func (e *Encoder) EncodeSliceLen(l int) error {
 	switch {
 	case l < 16:
 		if err := e.W.WriteByte(fixArrayLowCode | byte(l)); err != nil {
@@ -81,7 +81,7 @@ func (e *Encoder) encodeStringSlice(s []string) error {
 	if s == nil {
 		return e.EncodeNil()
 	}
-	if err := e.encodeSliceLen(len(s)); err != nil {
+	if err := e.EncodeSliceLen(len(s)); err != nil {
 		return err
 	}
 	for _, v := range s {
@@ -99,7 +99,7 @@ func (e *Encoder) encodeSlice(v reflect.Value) error {
 	}
 
 	l := v.Len()
-	if err := e.encodeSliceLen(l); err != nil {
+	if err := e.EncodeSliceLen(l); err != nil {
 		return err
 	}
 	for i := 0; i < l; i++ {


### PR DESCRIPTION
Notice we already have [`Deocder.DecodeSliceLen`](http://godoc.org/github.com/vmihailenco/msgpack#Decoder.DecodeSliceLen). This adds support for the `Encoder` equivalent.

**Use case**

This way arbitrary slices ([]`interface{}`) can be efficiently encoded and decoded with needing to resort to reflection.

e.g. (ignoring the handling of errors):

``` go
// type Client is defined elsewhere

type Encoder func(*msgpack.Encoder, interface{}) error

func (c *Client) makeCall(method string, args interface{}, e Encoder) (error) {
        // var enc *msgpack.Encoder

        // ....

    err = enc.EncodeSliceLen(4)
    err = enc.EncodeInt(req_type)
    err = enc.EncodeUint32(req_id)
    err = enc.EncodeString(req_meth_id)
    err = e(enc, args)

        // ....
}

```
