### PR TITLE
Add extended types

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -44,4 +44,13 @@ const (
 	fixMapMask     = 0xf
 	map16Code      = 0xde
 	map32Code      = 0xdf
+
+	fixExt1Code  = 0xd4
+	fixExt2Code  = 0xd5
+	fixExt4Code  = 0xd6
+	fixExt8Code  = 0xd7
+	fixExt16Code = 0xd8
+	ext8Code     = 0xc7
+	ext16Code    = 0xc8
+	ext32Code    = 0xc9
 )

--- a/encode.go
+++ b/encode.go
@@ -47,6 +47,7 @@ func Marshal(v ...interface{}) ([]byte, error) {
 type Encoder struct {
 	w   writer
 	buf []byte
+	m   *structCache
 }
 
 func NewEncoder(w io.Writer) *Encoder {
@@ -57,6 +58,7 @@ func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
 		w:   ww,
 		buf: make([]byte, 9),
+		m:   newStructCache(),
 	}
 }
 
@@ -113,7 +115,7 @@ func (e *Encoder) encode(iv interface{}) error {
 }
 
 func (e *Encoder) EncodeValue(v reflect.Value) error {
-	encode := getEncoder(v.Type())
+	encode := e.m.getEncoder(v.Type())
 	return encode(e, v)
 }
 

--- a/extended.go
+++ b/extended.go
@@ -1,0 +1,204 @@
+package msgpack
+
+import (
+	"errors"
+	"reflect"
+)
+
+type EncodeExtFunc func(reflect.Value) ([]byte, error)
+type DecodeExtFunc func(reflect.Value, []byte) error
+
+type decodeExtInfo struct {
+	DecodeType    reflect.Type
+	DecodeHandler DecodeExtFunc
+}
+
+type Extensions struct {
+	extensions map[int]*decodeExtInfo
+	decTypeMap map[reflect.Type]decoderFunc
+	encTypeMap map[reflect.Type]encoderFunc
+	encIntMap  map[reflect.Type]encoderFunc
+}
+
+func NewExtensions() *Extensions {
+	return &Extensions{
+		extensions: make(map[int]*decodeExtInfo),
+		decTypeMap: make(map[reflect.Type]decoderFunc),
+		encTypeMap: make(map[reflect.Type]encoderFunc),
+		encIntMap:  make(map[reflect.Type]encoderFunc),
+	}
+}
+
+func (ext *Extensions) AddExtension(code int, decType reflect.Type, encTypes []reflect.Type, encode EncodeExtFunc, decode DecodeExtFunc) {
+	ext.extensions[code] = &decodeExtInfo{
+		DecodeType:    decType,
+		DecodeHandler: decode,
+	}
+	encoder := func(e *Encoder, v reflect.Value) error {
+		b, err := encode(v)
+		if err != nil {
+			return err
+		}
+		return e.EncodeExtended(code, b)
+	}
+	ext.decTypeMap[decType] = func(d *Decoder, v reflect.Value) error {
+		c, b, err := d.DecodeExtendedBytes()
+		if err != nil {
+			return err
+		}
+		if c != code {
+			return errors.New("unexpected extended code")
+		}
+
+		return decode(v, b)
+	}
+	ext.encTypeMap[decType] = encoder
+	for _, t := range encTypes {
+		if t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Interface {
+			ext.encIntMap[t.Elem()] = encoder
+		} else {
+			ext.encTypeMap[t] = encoder
+		}
+	}
+}
+
+func (d *Decoder) DecodeExtendedBytes() (int, []byte, error) {
+	c, err := d.r.ReadByte()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var l int
+	switch c {
+	case fixExt1Code:
+		l = 1
+	case fixExt2Code:
+		l = 2
+	case fixExt4Code:
+		l = 4
+	case fixExt8Code:
+		l = 8
+	case fixExt16Code:
+		l = 16
+	case ext8Code:
+		v, err := d.uint8()
+		if err != nil {
+			return 0, nil, err
+		}
+		l = int(v)
+
+	case ext16Code:
+		v, err := d.uint16()
+		if err != nil {
+			return 0, nil, err
+		}
+		l = int(v)
+	case ext32Code:
+		v, err := d.uint32()
+		if err != nil {
+			return 0, nil, err
+		}
+		l = int(v)
+	default:
+		return 0, nil, errors.New("unexpected code")
+	}
+	typ, err := d.r.ReadByte()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	b, err := d.readN(l)
+
+	return int(typ), b, err
+}
+
+func (d *Decoder) DecodeExtended() (interface{}, error) {
+	typ, b, err := d.DecodeExtendedBytes()
+	if err != nil {
+		return nil, err
+	}
+	if d.m.ext == nil {
+		return nil, errors.New("no extended types")
+	}
+
+	ext := d.m.ext.extensions[int(typ)]
+	if ext == nil {
+		return nil, errors.New("extended type not registered")
+	}
+
+	v := reflect.New(ext.DecodeType).Elem()
+
+	if err := ext.DecodeHandler(v, b); err != nil {
+		return nil, err
+	}
+
+	return v.Interface(), nil
+}
+
+func (e *Encoder) EncodeExtended(ext int, data []byte) error {
+	switch l := len(data); {
+	case l == 1:
+		if err := e.w.WriteByte(fixExt1Code); err != nil {
+			return err
+		}
+	case l == 2:
+		if err := e.w.WriteByte(fixExt2Code); err != nil {
+			return err
+		}
+	case l == 4:
+		if err := e.w.WriteByte(fixExt4Code); err != nil {
+			return err
+		}
+	case l == 8:
+		if err := e.w.WriteByte(fixExt8Code); err != nil {
+			return err
+		}
+	case l == 16:
+		if err := e.w.WriteByte(fixExt16Code); err != nil {
+			return err
+		}
+	case l < 256:
+		if err := e.write([]byte{
+			ext8Code,
+			byte(l),
+		}); err != nil {
+			return err
+		}
+	case l < 65536:
+		if err := e.write([]byte{
+			ext16Code,
+			byte(l >> 8),
+			byte(l),
+		}); err != nil {
+			return err
+		}
+	default:
+		if err := e.write([]byte{
+			ext32Code,
+			byte(l >> 24),
+			byte(l >> 16),
+			byte(l >> 8),
+			byte(l),
+		}); err != nil {
+			return err
+		}
+	}
+	if err := e.w.WriteByte(byte(ext)); err != nil {
+		return err
+	}
+	return e.write(data)
+}
+
+func (m *structCache) addExtensions(ext *Extensions) {
+	m.l.Lock()
+	defer m.l.Unlock()
+	m.ext = ext
+}
+
+func (e *Encoder) AddExtensions(ext *Extensions) {
+	e.m.addExtensions(ext)
+}
+
+func (d *Decoder) AddExtensions(ext *Extensions) {
+	d.m.addExtensions(ext)
+}

--- a/extended_test.go
+++ b/extended_test.go
@@ -1,0 +1,208 @@
+package msgpack
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+type SimpleStruct struct {
+	b []byte
+}
+
+var testBytes = [][]byte{
+	[]byte{1, 2, 4, 8, 16},
+	[]byte{1, 3, 9, 27, 81},
+	[]byte{4, 9, 16, 25, 64},
+	[]byte{1, 4, 16, 64},
+	[]byte{1, 1, 2, 3, 5, 8, 13, 21},
+}
+
+func TestExtendedSimple(t *testing.T) {
+	table := []struct {
+		s *SimpleStruct
+		b []byte
+	}{
+		{&SimpleStruct{testBytes[0]}, append([]byte{0xc7, 0x05, 0x07}, testBytes[0]...)},
+		{&SimpleStruct{testBytes[1]}, append([]byte{0xc7, 0x05, 0x07}, testBytes[1]...)},
+		{&SimpleStruct{testBytes[2]}, append([]byte{0xc7, 0x05, 0x07}, testBytes[2]...)},
+		{&SimpleStruct{testBytes[3]}, append([]byte{0xd6, 0x07}, testBytes[3]...)},
+		{&SimpleStruct{testBytes[4]}, append([]byte{0xd7, 0x07}, testBytes[4]...)},
+	}
+
+	EncodeSimpleStruct := func(v reflect.Value) ([]byte, error) {
+		switch iv := v.Interface().(type) {
+		case *SimpleStruct:
+			return iv.b, nil
+		}
+		return nil, errors.New("unsupported encode type")
+	}
+
+	DecodeSimpleStruct := func(v reflect.Value, b []byte) error {
+		es, ok := v.Interface().(*SimpleStruct)
+		if !ok {
+			return fmt.Errorf("Unexpected value: %T", v.Interface())
+		}
+		if es == nil {
+			es = new(SimpleStruct)
+			v.Set(reflect.ValueOf(es))
+		}
+
+		es.b = b
+		return nil
+	}
+
+	extensions := NewExtensions()
+	extensions.AddExtension(7, reflect.TypeOf(&SimpleStruct{}), nil, EncodeSimpleStruct, DecodeSimpleStruct)
+
+	buf := &bytes.Buffer{}
+	encoder := NewEncoder(buf)
+	encoder.AddExtensions(extensions)
+	for _, test := range table {
+		if err := encoder.Encode(test.s); err != nil {
+			t.Fatalf("Error encoding struct")
+		}
+		if bytes.Compare(buf.Bytes(), test.b) != 0 {
+			t.Errorf("Unexpected byte value\n\tExpected: %x\n\tActual: %x", test.b, buf.Bytes())
+		}
+
+		d := NewDecoder(bytes.NewBuffer(buf.Bytes()))
+		d.AddExtensions(extensions)
+		var es SimpleStruct
+		if err := d.Decode(&es); err != nil {
+			t.Fatalf("Error decoding bytes: %s", err)
+		}
+		if bytes.Compare(test.s.b, es.b) != 0 {
+			t.Errorf("Unexpected byte value\n\tExpected; %x\n\tActual: %x", test.s.b, es.b)
+		}
+
+		// Decode as interface
+		d = NewDecoder(bytes.NewBuffer(buf.Bytes()))
+		d.AddExtensions(extensions)
+		var iVal interface{}
+		if err := d.Decode(&iVal); err != nil {
+			t.Fatalf("Error decoding bytes: %s", err)
+		}
+		if es, ok := iVal.(*SimpleStruct); !ok {
+			t.Fatalf("Unexpected interface value: %T", iVal)
+		} else if bytes.Compare(test.s.b, es.b) != 0 {
+			t.Errorf("Unexpected byte value\n\tExpected; %x\n\tActual: %x", test.s.b, es.b)
+		}
+
+		buf.Reset()
+	}
+
+}
+
+func (s *SimpleStruct) Read(b []byte) (int, error) {
+	return copy(b, s.b), nil
+}
+
+func TestExtendedInterfaces(t *testing.T) {
+	table := []struct {
+		s *SimpleStruct
+		b []byte
+	}{
+		{&SimpleStruct{testBytes[0]}, []byte{0xd4, 0x11, 0x00}},
+		{&SimpleStruct{testBytes[1]}, []byte{0xd4, 0x11, 0x01}},
+		{&SimpleStruct{testBytes[2]}, []byte{0xd4, 0x11, 0x02}},
+		{&SimpleStruct{testBytes[3]}, []byte{0xd4, 0x11, 0x03}},
+		{&SimpleStruct{testBytes[4]}, []byte{0xd4, 0x11, 0x04}},
+	}
+
+	type ReaderWrapper struct {
+		io.Reader
+	}
+	readers := make([]*ReaderWrapper, 0)
+
+	EncodeReader := func(iv reflect.Value) ([]byte, error) {
+		switch v := iv.Interface().(type) {
+		case *ReaderWrapper:
+			readers = append(readers, v)
+			return []byte{byte(len(readers) - 1)}, nil
+		case io.Reader:
+			readers = append(readers, &ReaderWrapper{v})
+			return []byte{byte(len(readers) - 1)}, nil
+		}
+
+		return nil, fmt.Errorf("unsupported type: %T", iv.Interface())
+	}
+	DecodeReader := func(v reflect.Value, b []byte) error {
+		if len(b) > 1 {
+			return fmt.Errorf("unexpected error length: %d", len(b))
+		}
+		i := int(b[0])
+		if i >= len(readers) {
+			return fmt.Errorf("unknown index: %d", i)
+		}
+		if !v.CanSet() {
+			v.Elem().Set(reflect.ValueOf(*readers[i]))
+		} else {
+			v.Set(reflect.ValueOf(readers[i]))
+		}
+
+		return nil
+	}
+	extensions := NewExtensions()
+	extensions.AddExtension(17, reflect.TypeOf(new(ReaderWrapper)), []reflect.Type{reflect.TypeOf(new(io.Reader))}, EncodeReader, DecodeReader)
+
+	buf := &bytes.Buffer{}
+	encoder := NewEncoder(buf)
+	encoder.AddExtensions(extensions)
+	for _, test := range table {
+		if err := encoder.Encode(test.s); err != nil {
+			t.Fatalf("Error encoding struct")
+		}
+		if bytes.Compare(buf.Bytes(), test.b) != 0 {
+			t.Errorf("Unexpected byte value\n\tExpected: %x\n\tActual: %x", test.b, buf.Bytes())
+		}
+
+		d := NewDecoder(bytes.NewBuffer(buf.Bytes()))
+		d.AddExtensions(extensions)
+		var rw ReaderWrapper
+		if err := d.Decode(&rw); err != nil {
+			t.Fatalf("Error decoding bytes: %s", err)
+		}
+		if rw.Reader != test.s {
+			t.Errorf("Unexpected reader value\n\tExpected: %p\n\tActual: %p", test.s, rw.Reader)
+		}
+		readBytes := make([]byte, len(test.s.b))
+		if n, err := rw.Read(readBytes); err != nil {
+			t.Errorf("Error reading bytes: %s", err)
+		} else if n != len(test.s.b) {
+			t.Errorf("Unexpected read length\n\tExpected: %d\n\tActual: %d", len(test.s.b), n)
+		}
+		if bytes.Compare(test.s.b, readBytes) != 0 {
+			t.Errorf("Unexpected byte value\n\tExpected: %x\n\tActual: %x", test.s.b, readBytes)
+		}
+
+		// Decode as interface
+		d = NewDecoder(bytes.NewBuffer(buf.Bytes()))
+		d.AddExtensions(extensions)
+		var iVal io.Reader
+		if err := d.Decode(&iVal); err != nil {
+			t.Fatalf("Error decoding bytes: %s", err)
+		}
+		if rw, ok := iVal.(*ReaderWrapper); !ok {
+			t.Fatalf("Unexpected interface value: %T", iVal)
+		} else {
+			if rw.Reader != test.s {
+				t.Errorf("Unexpected reader value\n\tExpected: %p\n\tActual: %p", test.s, rw.Reader)
+			}
+			readBytes := make([]byte, len(test.s.b))
+			if n, err := rw.Read(readBytes); err != nil {
+				t.Errorf("Error reading bytes: %s", err)
+			} else if n != len(test.s.b) {
+				t.Errorf("Unexpected read length\n\tExpected: %d\n\tActual: %d", len(test.s.b), n)
+			}
+			if bytes.Compare(test.s.b, readBytes) != 0 {
+				t.Errorf("Unexpected byte value\n\tExpected: %x\n\tActual: %x", test.s.b, readBytes)
+			}
+		}
+
+		buf.Reset()
+	}
+}


### PR DESCRIPTION
Adds support for encoding and decoding extended types.  Also has support for encoding and decoding interfaces.

Still working on unit tests, but would appreciate a review on the design and layout

For use in https://github.com/docker/libchan