### PR TITLE
Add support for inlining struct fields.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: go
 go:
   - 1.3
   - 1.4
+  - 1.5
   - tip
+
+sudo: false
 
 install:
   - go get gopkg.in/check.v1

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Supports:
 - Appengine *datastore.Key and datastore.Cursor.
 - Marshaler/Unmarshaler interfaces for custom encoding.
 - Struct field renaming, e.g. `msgpack:"my_field_name"`.
+- Struct field inlining, e.g. `msgpack:",inline"`.
 - Omitempty flag, e.g. `msgpack:",omitempty"`.
 
 API docs: http://godoc.org/gopkg.in/vmihailenco/msgpack.v2

--- a/decode.go
+++ b/decode.go
@@ -163,7 +163,7 @@ func (d *Decoder) decode(iv interface{}) error {
 }
 
 func (d *Decoder) DecodeValue(v reflect.Value) error {
-	decode := getDecoder(v.Type())
+	decode, _ := getDecoder(v.Type())
 	return decode(d, v)
 }
 

--- a/encode.go
+++ b/encode.go
@@ -115,7 +115,7 @@ func (e *Encoder) encode(iv interface{}) error {
 }
 
 func (e *Encoder) EncodeValue(v reflect.Value) error {
-	encode := getEncoder(v.Type())
+	encode, _ := getEncoder(v.Type())
 	return encode(e, v)
 }
 

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -490,6 +490,10 @@ type testStruct struct {
 	Tm     time.Time
 	Data   []byte
 	Colors []string
+	Inline struct {
+		Value string
+		Num   int64
+	} `msgpack:",inline"`
 }
 
 func TestStruct(t *testing.T) {
@@ -499,6 +503,8 @@ func TestStruct(t *testing.T) {
 		Data:   []byte{1, 2, 3},
 		Colors: []string{"red", "orange", "yellow", "green", "blue", "violet"},
 	}
+	in.Inline.Value = "hello"
+	in.Inline.Num = 8868
 	var out testStruct
 
 	b, err := msgpack.Marshal(in)

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -578,6 +578,10 @@ type coderStruct struct {
 	name string
 }
 
+type wrapperStruct struct {
+	coderStruct `msgpack:",inline"`
+}
+
 var (
 	_ msgpack.CustomEncoder = &coderStruct{}
 	_ msgpack.CustomDecoder = &coderStruct{}
@@ -626,6 +630,14 @@ func (t *MsgpackTest) TestPtrToCoder(c *C) {
 	out2 := &out
 	c.Assert(t.enc.Encode(in), IsNil)
 	c.Assert(t.dec.Decode(&out2), IsNil)
+	c.Assert(out.Name(), Equals, "hello")
+}
+
+func (t *MsgpackTest) TestWrappedCoder(c *C) {
+	in := &wrapperStruct{coderStruct: coderStruct{name: "hello"}}
+	var out wrapperStruct
+	c.Assert(t.enc.Encode(in), IsNil)
+	c.Assert(t.dec.Decode(&out), IsNil)
 	c.Assert(out.Name(), Equals, "hello")
 }
 

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -522,6 +522,37 @@ func TestStruct(t *testing.T) {
 	}
 }
 
+type CustomTime struct {
+	time.Time
+}
+
+type CustomTimeInline struct {
+	time.Time `msgpack:",inline"`
+}
+
+func TestCustomTime(t *testing.T) {
+	cases := []struct {
+		in, out interface{}
+	}{
+		{&CustomTime{Time: time.Now()}, &CustomTime{}},
+		{&CustomTimeInline{Time: time.Now()}, &CustomTimeInline{}},
+	}
+	for i, cas := range cases {
+		p, err := msgpack.Marshal(cas.in)
+		if err != nil {
+			t.Errorf("msgpack.Marshal(%# v)=%s (i=%d)", t, err, i)
+			continue
+		}
+		if err = msgpack.Unmarshal(p, cas.out); err != nil {
+			t.Errorf("msgpack.Unmarshal(%v)=%s (i=%d)", p, err, i)
+			continue
+		}
+		if !reflect.DeepEqual(cas.out, cas.in) {
+			t.Errorf("want cas.out=%v; got %v (i=%d)", cas.in, cas.out, i)
+		}
+	}
+}
+
 func (t *MsgpackTest) TestStructUnknownField(c *C) {
 	in := struct {
 		Field1 string

--- a/tags.go
+++ b/tags.go
@@ -31,7 +31,7 @@ func (o tagOptions) Contains(optionName string) bool {
 	s := string(o)
 	for s != "" {
 		var next string
-		i := strings.Index(s, ",")
+		i := strings.IndexRune(s, ',')
 		if i >= 0 {
 			s, next = s[:i], s[i+1:]
 		}

--- a/types_test.go
+++ b/types_test.go
@@ -72,9 +72,13 @@ type compactEncodingStructField struct {
 
 //------------------------------------------------------------------------------
 
-type omitEmptyTest struct {
+type OmitEmptyTest struct {
 	Foo string `msgpack:",omitempty"`
 	Bar string `msgpack:",omitempty"`
+}
+
+type InlineTest struct {
+	OmitEmptyTest `msgpack:",inline"`
 }
 
 //------------------------------------------------------------------------------
@@ -86,7 +90,7 @@ type binTest struct {
 
 var binTests = []binTest{
 	{nil, []byte{codes.Nil}},
-	{omitEmptyTest{}, []byte{codes.FixedMapLow}},
+	{OmitEmptyTest{}, []byte{codes.FixedMapLow}},
 
 	{intSet{}, []byte{codes.FixedArrayLow}},
 	{intSet{8: struct{}{}}, []byte{codes.FixedArrayLow | 1, 0x8}},
@@ -99,12 +103,19 @@ var binTests = []binTest{
 }
 
 func init() {
-	test := binTest{in: &omitEmptyTest{Foo: "hello"}}
+	test := binTest{in: &OmitEmptyTest{Foo: "hello"}}
 	test.wanted = append(test.wanted, codes.FixedMapLow|0x01)
 	test.wanted = append(test.wanted, codes.FixedStrLow|byte(len("Foo")))
 	test.wanted = append(test.wanted, "Foo"...)
 	test.wanted = append(test.wanted, codes.FixedStrLow|byte(len("hello")))
 	test.wanted = append(test.wanted, "hello"...)
+	binTests = append(binTests, test)
+	test = binTest{in: &InlineTest{OmitEmptyTest: OmitEmptyTest{Bar: "world"}}}
+	test.wanted = append(test.wanted, codes.FixedMapLow|0x01)
+	test.wanted = append(test.wanted, codes.FixedStrLow|byte(len("Bar")))
+	test.wanted = append(test.wanted, "Bar"...)
+	test.wanted = append(test.wanted, codes.FixedStrLow|byte(len("world")))
+	test.wanted = append(test.wanted, "world"...)
 	binTests = append(binTests, test)
 }
 


### PR DESCRIPTION
msgpack encoder differ in behaviour from the json one - the latter inlines
fields of an embedded struct as they were part of the parent struct.

While we can't change the behaviour due to compatibility reasons we can
introduce `inline` opt, which will make the encoding similar in
behaviour to the json one.

/cc @vmihailenco Please take a look.