### PR TITLE
Add API to skip next value.

### DIFF
--- a/decode_number.go
+++ b/decode_number.go
@@ -8,6 +8,11 @@ import (
 	"gopkg.in/vmihailenco/msgpack.v2/codes"
 )
 
+func (d *Decoder) skipN(n int) error {
+	_, err := d.readN(n)
+	return err
+}
+
 func (d *Decoder) uint8() (uint8, error) {
 	c, err := d.r.ReadByte()
 	if err != nil {

--- a/ext.go
+++ b/ext.go
@@ -86,6 +86,10 @@ func (d *Decoder) decodeExtLen() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	return d.extLen(c)
+}
+
+func (d *Decoder) extLen(c byte) (int, error) {
 	switch c {
 	case codes.FixExt1:
 		return 1, nil
@@ -130,4 +134,12 @@ func (d *Decoder) decodeExt() (interface{}, error) {
 		return nil, err
 	}
 	return v.Interface(), nil
+}
+
+func (d *Decoder) skipExt(c byte) error {
+	n, err := d.extLen(c)
+	if err != nil {
+		return err
+	}
+	return d.skipN(n)
 }

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -931,6 +931,47 @@ func BenchmarkStruct(b *testing.B) {
 	}
 }
 
+func BenchmarkStructDecode(b *testing.B) {
+	in := structForBenchmark()
+	buf, err := msgpack.Marshal(in)
+	if err != nil {
+		b.Fatal(err)
+	}
+	out := &benchmarkStruct{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err = msgpack.Unmarshal(buf, out)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+type benchmarkSubStruct struct {
+	Name string
+	Age  int
+}
+
+func BenchmarkStructDecodePartially(b *testing.B) {
+	in := structForBenchmark()
+	buf, err := msgpack.Marshal(in)
+	if err != nil {
+		b.Fatal(err)
+	}
+	out := &benchmarkSubStruct{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err = msgpack.Unmarshal(buf, out)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkStructManual(b *testing.B) {
 	in := structForBenchmark2()
 	out := &benchmarkStruct2{}

--- a/slice.go
+++ b/slice.go
@@ -123,6 +123,10 @@ func (d *Decoder) DecodeBytesLen() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	return d.bytesLen(c)
+}
+
+func (d *Decoder) bytesLen(c byte) (int, error) {
 	if c == codes.Nil {
 		return -1, nil
 	} else if c >= codes.FixedStrLow && c <= codes.FixedStrHigh {
@@ -156,6 +160,17 @@ func (d *Decoder) DecodeBytes() ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+func (d *Decoder) skipBytes(c byte) error {
+	n, err := d.bytesLen(c)
+	if err != nil {
+		return err
+	}
+	if n == -1 {
+		return nil
+	}
+	return d.skipN(n)
 }
 
 func (d *Decoder) bytesValue(value reflect.Value) error {
@@ -196,6 +211,10 @@ func (d *Decoder) DecodeSliceLen() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	return d.sliceLen(c)
+}
+
+func (d *Decoder) sliceLen(c byte) (int, error) {
 	if c == codes.Nil {
 		return -1, nil
 	} else if c >= codes.FixedArrayLow && c <= codes.FixedArrayHigh {
@@ -255,6 +274,21 @@ func (d *Decoder) DecodeSlice() ([]interface{}, error) {
 	}
 
 	return s, nil
+}
+
+func (d *Decoder) skipSlice(c byte) error {
+	n, err := d.sliceLen(c)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < n; i++ {
+		if err := d.Skip(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (d *Decoder) sliceValue(v reflect.Value) error {

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -339,7 +339,7 @@ func decodeCustomValuePtr(d *Decoder, v reflect.Value) error {
 	if !v.CanAddr() {
 		return fmt.Errorf("msgpack: Decode(nonsettable %T)", v.Interface())
 	}
-	if d.hasNilCode() {
+	if d.gotNilCode() {
 		return d.DecodeNil()
 	}
 	decoder := v.Addr().Interface().(CustomDecoder)
@@ -347,7 +347,7 @@ func decodeCustomValuePtr(d *Decoder, v reflect.Value) error {
 }
 
 func decodeCustomValue(d *Decoder, v reflect.Value) error {
-	if d.hasNilCode() {
+	if d.gotNilCode() {
 		return d.DecodeNil()
 	}
 	if v.IsNil() {


### PR DESCRIPTION
This is useful when partially decoding data into struct. Updates https://github.com/vmihailenco/msgpack/issues/55

```
BenchmarkStruct-4               	  100000	     11709 ns/op	    3296 B/op	      27 allocs/op
BenchmarkStructDecode-4         	  300000	      4649 ns/op	    1456 B/op	      19 allocs/op
BenchmarkStructDecodePartially-4	  500000	      3301 ns/op	    1296 B/op	      11 allocs/op
BenchmarkStructManual-4         	  200000	      5800 ns/op	    2784 B/op	      21 allocs/op
BenchmarkStructMsgpack2-4       	  100000	     12773 ns/op	    3840 B/op	      70 allocs/op
BenchmarkStructMsgpack3-4       	  100000	     15527 ns/op	    7474 B/op	      29 allocs/op
BenchmarkStructJSON-4           	   30000	     52968 ns/op	    8088 B/op	      29 allocs/op
BenchmarkStructGOB-4            	   20000	     67890 ns/op	   15609 B/op	     299 allocs/op
```