### PR TITLE
Improved error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,9 @@ all:
 	go test gopkg.in/vmihailenco/msgpack.v2 -cpu=1
 	go test gopkg.in/vmihailenco/msgpack.v2 -cpu=2
 	go test gopkg.in/vmihailenco/msgpack.v2 -short -race
+
+dev:
+	go build -tags=dev
+	go test -tags=dev -cpu=1 .
+	go test -tags=dev -cpu=2 .
+	go test -tags=dev -short -race .

--- a/decode_number.go
+++ b/decode_number.go
@@ -1,7 +1,6 @@
 package msgpack
 
 import (
-	"fmt"
 	"math"
 	"reflect"
 
@@ -91,7 +90,7 @@ func (d *Decoder) uint(c byte) (uint64, error) {
 	case codes.Uint64, codes.Int64:
 		return d.uint64()
 	}
-	return 0, fmt.Errorf("msgpack: invalid code %x decoding uint64", c)
+	return 0, InvalidCodeError{c, "uint64"}
 }
 
 func (d *Decoder) uint64Value(value reflect.Value) error {
@@ -138,7 +137,7 @@ func (d *Decoder) int(c byte) (int64, error) {
 		n, err := d.uint64()
 		return int64(n), err
 	}
-	return 0, fmt.Errorf("msgpack: invalid code %x decoding int64", c)
+	return 0, InvalidCodeError{c, "int64"}
 }
 
 func (d *Decoder) int64Value(v reflect.Value) error {
@@ -160,7 +159,7 @@ func (d *Decoder) DecodeFloat32() (float32, error) {
 
 func (d *Decoder) float32(c byte) (float32, error) {
 	if c != codes.Float {
-		return 0, fmt.Errorf("msgpack: invalid code %x decoding float32", c)
+		return 0, InvalidCodeError{c, "float32"}
 	}
 	b, err := d.uint32()
 	if err != nil {
@@ -192,7 +191,7 @@ func (d *Decoder) float64(c byte) (float64, error) {
 		return float64(n), err
 	}
 	if c != codes.Double {
-		return 0, fmt.Errorf("msgpack: invalid code %x decoding float64", c)
+		return 0, InvalidCodeError{c, "float64"}
 	}
 	b, err := d.uint64()
 	if err != nil {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,103 @@
+package msgpack
+
+import (
+	"fmt"
+)
+
+// A DupExtIdError represents an error when is requested to register an extended
+// type and its identifier already exists.
+type DupExtIdError byte
+
+// Error returns string representation of current instance error.
+func (e DupExtIdError) Error() string {
+	return fmt.Sprintf("ext with id %d is already registered", byte(e))
+}
+
+// An InvalidCodeError represents an error when the code of encoded data doesn't
+// match which the type of provided variable.
+type InvalidCodeError struct {
+	Code     byte
+	TypeName string
+}
+
+// Error returns string representation of current instance error.
+func (e InvalidCodeError) Error() string {
+	return fmt.Sprintf("msgpack: invalid code %x decoding %s",
+		e.Code, e.TypeName)
+}
+
+// A NonAddressableError represents an error when is unable to obtain the
+// pointer of destination variable.
+type NonAddressableError struct {
+	Value interface{}
+}
+
+// Error returns string representation of current instance error.
+func (e NonAddressableError) Error() string {
+	return fmt.Sprintf("msgpack: Encode(non-addressable %T)", e.Value)
+}
+
+// A NotSettableError represents an error when trying to decode to a variable
+// that is not a pointer.
+type NotSettableError struct {
+	Value interface{}
+}
+
+// Error returns string representation of current instance error.
+func (e NotSettableError) Error() string {
+	return fmt.Sprintf("msgpack: Decode(nonsettable %T)", e.Value)
+}
+
+// A NullDestError represents an error when trying to decode to a null variable.
+type NullDestError int
+
+// Error returns string representation of current instance error.
+func (e NullDestError) Error() string {
+	return "msgpack: Decode(nil)"
+}
+
+// An UnknownCodeError represents an error when the code of encoded data doesn't
+// match which the type of provided variable.
+type UnknownCodeError struct {
+	Code     byte
+	TypeName string
+}
+
+// Error returns string representation of current instance error.
+func (e UnknownCodeError) Error() string {
+	if len(e.TypeName) > 0 {
+		return fmt.Sprintf("msgpack: unknown code %x decoding %s",
+			e.Code, e.TypeName)
+	} else {
+		return fmt.Sprintf("msgpack: unknown code %x",
+			e.Code)
+	}
+}
+
+// An UnregisteredExtError represents an error when trying to decode an
+// unregistered extended type.
+type UnregisteredExtError byte
+
+// Error returns string representation of current instance error.
+func (e UnregisteredExtError) Error() string {
+	return fmt.Sprintf("msgpack: unregistered ext id %d", byte(e))
+}
+
+// An UnsupportedTypeError represents an error when trying to encode or decode
+// an unsupported type.
+type UnsupportedTypeError struct {
+	Encoding bool
+	Value    interface{}
+}
+
+// Error returns string representation of current instance error.
+func (e UnsupportedTypeError) Error() string {
+	var op string
+	if e.Encoding {
+		op = "Encode"
+	} else {
+		op = "Decode"
+	}
+
+	return fmt.Sprintf("msgpack: %s(unsupported %T)", op, e.Value)
+}

--- a/ext_test.go
+++ b/ext_test.go
@@ -1,14 +1,13 @@
-package msgpack_test
+package msgpack
 
 import (
 	"testing"
 
-	"gopkg.in/vmihailenco/msgpack.v2"
 	"gopkg.in/vmihailenco/msgpack.v2/codes"
 )
 
 func init() {
-	msgpack.RegisterExt(0, extTest{})
+	RegisterExt(0, extTest{})
 }
 
 func TestRegisterExtPanic(t *testing.T) {
@@ -23,7 +22,7 @@ func TestRegisterExtPanic(t *testing.T) {
 			t.Fatalf("got %q, wanted %q", got, wanted)
 		}
 	}()
-	msgpack.RegisterExt(0, extTest{})
+	RegisterExt(0, extTest{})
 }
 
 type extTest struct {
@@ -36,13 +35,13 @@ type extTest2 struct {
 
 func TestExt(t *testing.T) {
 	for _, v := range []interface{}{extTest{"hello"}, &extTest{"hello"}} {
-		b, err := msgpack.Marshal(v)
+		b, err := Marshal(v)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		var dst interface{}
-		err = msgpack.Unmarshal(b, &dst)
+		err = Unmarshal(b, &dst)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -61,7 +60,7 @@ func TestUnknownExt(t *testing.T) {
 	b := []byte{codes.FixExt1, 1, 0}
 
 	var dst interface{}
-	err := msgpack.Unmarshal(b, &dst)
+	err := Unmarshal(b, &dst)
 	if err == nil {
 		t.Fatalf("got nil, wanted error")
 	}

--- a/ext_test.go
+++ b/ext_test.go
@@ -16,10 +16,9 @@ func TestRegisterExtPanic(t *testing.T) {
 		if r == nil {
 			t.Fatalf("panic expected")
 		}
-		got := r.(error).Error()
-		wanted := "ext with id 0 is already registered"
-		if got != wanted {
-			t.Fatalf("got %q, wanted %q", got, wanted)
+		_, ok := r.(DupExtIdError)
+		if !ok {
+			t.Fatalf("Unexpected panic type: %T", r)
 		}
 	}()
 	RegisterExt(0, extTest{})
@@ -64,9 +63,8 @@ func TestUnknownExt(t *testing.T) {
 	if err == nil {
 		t.Fatalf("got nil, wanted error")
 	}
-	got := err.Error()
-	wanted := "msgpack: unregistered ext id 1"
-	if got != wanted {
-		t.Fatalf("got %q, wanted %q", got, wanted)
+	_, ok := err.(UnregisteredExtError)
+	if !ok {
+		t.Fatalf("Unexpected error type: %T", err)
 	}
 }

--- a/map.go
+++ b/map.go
@@ -1,7 +1,6 @@
 package msgpack
 
 import (
-	"fmt"
 	"reflect"
 
 	"gopkg.in/vmihailenco/msgpack.v2/codes"
@@ -94,7 +93,7 @@ func (d *Decoder) mapLen(c byte) (int, error) {
 		n, err := d.uint32()
 		return int(n), err
 	}
-	return 0, fmt.Errorf("msgpack: invalid code %x decoding map length", c)
+	return 0, InvalidCodeError{c, "map length"}
 }
 
 func (d *Decoder) decodeIntoMapStringString(mp *map[string]string) error {

--- a/msgpack.go
+++ b/msgpack.go
@@ -1,4 +1,4 @@
-package msgpack // import "gopkg.in/vmihailenco/msgpack.v2"
+package msgpack
 
 // Deprecated. Use CustomEncoder.
 type Marshaler interface {

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -1,4 +1,4 @@
-package msgpack_test
+package msgpack
 
 import (
 	"bufio"
@@ -11,7 +11,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/vmihailenco/msgpack.v2"
 	"gopkg.in/vmihailenco/msgpack.v2/codes"
 )
 
@@ -23,16 +22,16 @@ func Test(t *testing.T) { TestingT(t) }
 
 type MsgpackTest struct {
 	buf *bytes.Buffer
-	enc *msgpack.Encoder
-	dec *msgpack.Decoder
+	enc *Encoder
+	dec *Decoder
 }
 
 var _ = Suite(&MsgpackTest{})
 
 func (t *MsgpackTest) SetUpTest(c *C) {
 	t.buf = &bytes.Buffer{}
-	t.enc = msgpack.NewEncoder(t.buf)
-	t.dec = msgpack.NewDecoder(bufio.NewReader(t.buf))
+	t.enc = NewEncoder(t.buf)
+	t.dec = NewDecoder(bufio.NewReader(t.buf))
 }
 
 func (t *MsgpackTest) TestUint64(c *C) {
@@ -497,19 +496,19 @@ type wrapperStruct struct {
 }
 
 var (
-	_ msgpack.CustomEncoder = &coderStruct{}
-	_ msgpack.CustomDecoder = &coderStruct{}
+	_ CustomEncoder = (*coderStruct)(nil)
+	_ CustomDecoder = (*coderStruct)(nil)
 )
 
 func (s *coderStruct) Name() string {
 	return s.name
 }
 
-func (s *coderStruct) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (s *coderStruct) EncodeMsgpack(enc *Encoder) error {
 	return enc.Encode(s.name)
 }
 
-func (s *coderStruct) DecodeMsgpack(dec *msgpack.Decoder) error {
+func (s *coderStruct) DecodeMsgpack(dec *Decoder) error {
 	return dec.Decode(&s.name)
 }
 
@@ -595,12 +594,12 @@ func TestEmbedding(t *testing.T) {
 	}
 	var out Struct3
 
-	b, err := msgpack.Marshal(in)
+	b, err := Marshal(in)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = msgpack.Unmarshal(b, &out)
+	err = Unmarshal(b, &out)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -642,9 +641,9 @@ func (t *MsgpackTest) TestMapStringInterface(c *C) {
 
 func (t *MsgpackTest) TestMapStringInterface2(c *C) {
 	buf := &bytes.Buffer{}
-	enc := msgpack.NewEncoder(buf)
-	dec := msgpack.NewDecoder(buf)
-	dec.DecodeMapFunc = func(d *msgpack.Decoder) (interface{}, error) {
+	enc := NewEncoder(buf)
+	dec := NewDecoder(buf)
+	dec.DecodeMapFunc = func(d *Decoder) (interface{}, error) {
 		n, err := d.DecodeMapLen()
 		if err != nil {
 			return nil, err

--- a/release.go
+++ b/release.go
@@ -1,0 +1,3 @@
+// +build !dev
+
+package msgpack // import "gopkg.in/vmihailenco/msgpack.v2"

--- a/slice.go
+++ b/slice.go
@@ -1,7 +1,6 @@
 package msgpack
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 
@@ -123,7 +122,7 @@ func (d *Decoder) bytesLen(c byte) (int, error) {
 		n, err := d.uint32()
 		return int(n), err
 	}
-	return 0, fmt.Errorf("msgpack: invalid code %x decoding bytes length", c)
+	return 0, InvalidCodeError{c, "bytes length"}
 }
 
 func (d *Decoder) DecodeBytes() ([]byte, error) {
@@ -233,7 +232,7 @@ func (d *Decoder) sliceLen(c byte) (int, error) {
 		n, err := d.uint32()
 		return int(n), err
 	}
-	return 0, fmt.Errorf("msgpack: invalid code %x decoding array length", c)
+	return 0, InvalidCodeError{c, "array length"}
 }
 
 func (d *Decoder) decodeIntoStrings(sp *[]string) error {

--- a/time.go
+++ b/time.go
@@ -1,7 +1,6 @@
 package msgpack
 
 import (
-	"fmt"
 	"reflect"
 	"time"
 )
@@ -30,7 +29,7 @@ func (d *Decoder) DecodeTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 	if b != 0x92 {
-		return time.Time{}, fmt.Errorf("msgpack: invalid code %x decoding time", b)
+		return time.Time{}, InvalidCodeError{b, "time"}
 	}
 
 	sec, err := d.DecodeInt64()

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -1,7 +1,6 @@
 package msgpack
 
 import (
-	"fmt"
 	"io/ioutil"
 	"reflect"
 	"sync"
@@ -220,11 +219,11 @@ func inlineFields(fs *fields, f reflect.StructField) {
 //------------------------------------------------------------------------------
 
 func encodeUnsupportedValue(e *Encoder, v reflect.Value) error {
-	return fmt.Errorf("msgpack: Encode(unsupported %T)", v.Interface())
+	return UnsupportedTypeError{true, v.Interface()}
 }
 
 func decodeUnsupportedValue(d *Decoder, v reflect.Value) error {
-	return fmt.Errorf("msgpack: Decode(unsupported %T)", v.Interface())
+	return UnsupportedTypeError{false, v.Interface()}
 }
 
 //------------------------------------------------------------------------------
@@ -368,7 +367,7 @@ func encodePtrValue(e *Encoder, v reflect.Value) error {
 func decodePtrValue(d *Decoder, v reflect.Value) error {
 	if v.IsNil() {
 		if !v.CanSet() {
-			return fmt.Errorf("msgpack: Decode(nonsettable %T)", v.Interface())
+			return NotSettableError{v.Interface()}
 		}
 		vv := reflect.New(v.Type().Elem())
 		v.Set(vv)
@@ -390,7 +389,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 
 func encodeCustomValuePtr(e *Encoder, v reflect.Value) error {
 	if !v.CanAddr() {
-		return fmt.Errorf("msgpack: Encode(non-addressable %T)", v.Interface())
+		return NonAddressableError{v.Interface()}
 	}
 	switch v.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
@@ -415,7 +414,7 @@ func encodeCustomValue(e *Encoder, v reflect.Value) error {
 
 func decodeCustomValuePtr(d *Decoder, v reflect.Value) error {
 	if !v.CanAddr() {
-		return fmt.Errorf("msgpack: Decode(nonsettable %T)", v.Interface())
+		return NotSettableError{v.Interface()}
 	}
 	if d.gotNilCode() {
 		return d.DecodeNil()

--- a/types_test.go
+++ b/types_test.go
@@ -1,11 +1,10 @@
-package msgpack_test
+package msgpack
 
 import (
 	"reflect"
 	"testing"
 	"time"
 
-	"gopkg.in/vmihailenco/msgpack.v2"
 	"gopkg.in/vmihailenco/msgpack.v2/codes"
 )
 
@@ -14,11 +13,11 @@ import (
 type intSet map[int]struct{}
 
 var (
-	_ msgpack.CustomEncoder = (*intSet)(nil)
-	_ msgpack.CustomDecoder = (*intSet)(nil)
+	_ CustomEncoder = (*intSet)(nil)
+	_ CustomDecoder = (*intSet)(nil)
 )
 
-func (set intSet) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (set intSet) EncodeMsgpack(enc *Encoder) error {
 	slice := make([]int, 0, len(set))
 	for n, _ := range set {
 		slice = append(slice, n)
@@ -26,7 +25,7 @@ func (set intSet) EncodeMsgpack(enc *msgpack.Encoder) error {
 	return enc.Encode(slice)
 }
 
-func (setptr *intSet) DecodeMsgpack(dec *msgpack.Decoder) error {
+func (setptr *intSet) DecodeMsgpack(dec *Decoder) error {
 	n, err := dec.DecodeSliceLen()
 	if err != nil {
 		return err
@@ -54,15 +53,15 @@ type CompactEncodingTest struct {
 }
 
 var (
-	_ msgpack.CustomEncoder = (*CompactEncodingTest)(nil)
-	_ msgpack.CustomDecoder = (*CompactEncodingTest)(nil)
+	_ CustomEncoder = (*CompactEncodingTest)(nil)
+	_ CustomDecoder = (*CompactEncodingTest)(nil)
 )
 
-func (s *CompactEncodingTest) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (s *CompactEncodingTest) EncodeMsgpack(enc *Encoder) error {
 	return enc.Encode(s.str, s.ref, s.num)
 }
 
-func (s *CompactEncodingTest) DecodeMsgpack(dec *msgpack.Decoder) error {
+func (s *CompactEncodingTest) DecodeMsgpack(dec *Decoder) error {
 	return dec.Decode(&s.str, &s.ref, &s.num)
 }
 
@@ -126,7 +125,7 @@ func init() {
 
 func TestBin(t *testing.T) {
 	for _, test := range binTests {
-		b, err := msgpack.Marshal(test.in)
+		b, err := Marshal(test.in)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -255,7 +254,7 @@ func TestTypes(t *testing.T) {
 	for _, test := range typeTests {
 		test.T = t
 
-		b, err := msgpack.Marshal(test.in)
+		b, err := Marshal(test.in)
 		if test.encErr != "" {
 			test.assertErr(err, test.encErr)
 			continue
@@ -264,7 +263,7 @@ func TestTypes(t *testing.T) {
 			t.Fatalf("Marshal failed: %s (in=%#v)", err, test.in)
 		}
 
-		err = msgpack.Unmarshal(b, test.out)
+		err = Unmarshal(b, test.out)
 		if test.decErr != "" {
 			test.assertErr(err, test.decErr)
 			continue


### PR DESCRIPTION
Callers can check the error by type assertion instead of string matching and parsing.

Additionally, made changes to allow development builds and fixed testing code to target current state instead of tagged one.

**Note**: These changes doesn't break current callers, the error strings is still the same.