### PR TITLE
Fixed decoding of -1 (0xFF) wrapping to huge int.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -237,7 +237,7 @@ func (d *Decoder) DecodeInterface() (interface{}, error) {
 	}
 
 	if codes.IsFixedNum(c) {
-		if c >= 0 {
+		if int8(c) >= 0 {
 			return d.uint(c)
 		}
 		return d.int(c)


### PR DESCRIPTION
`c` is a byte which == uint8. When 0xff comes in from the stream, it's interpreted as 255 (unsigned), and this can never be < 0, so the if statement is invalid.