### PR TITLE
Decode ext format into map[string]interface{}

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -45,17 +45,33 @@ var (
 	Map16        byte = 0xde
 	Map32        byte = 0xdf
 
-	FixExt1  byte = 0xd4
-	FixExt2  byte = 0xd5
-	FixExt4  byte = 0xd6
-	FixExt8  byte = 0xd7
-	FixExt16 byte = 0xd8
-	Ext8     byte = 0xc7
-	Ext16    byte = 0xc8
-	Ext32    byte = 0xc9
+	FixExtLow  byte = 0xd4
+	FixExt1    byte = 0xd4
+	FixExt2    byte = 0xd5
+	FixExt4    byte = 0xd6
+	FixExt8    byte = 0xd7
+	FixExt16   byte = 0xd8
+	FixExtHigh byte = 0xd8
+	ExtLow     byte = 0xc7
+	Ext8       byte = 0xc7
+	Ext16      byte = 0xc8
+	Ext32      byte = 0xc9
+	ExtHigh    byte = 0xc9
 )
 
 func IsFixedNum(c byte) bool    { return c <= PosFixedNumHigh || c >= NegFixedNumLow }
 func IsFixedMap(c byte) bool    { return c >= FixedMapLow && c <= FixedMapHigh }
 func IsFixedArray(c byte) bool  { return c >= FixedArrayLow && c <= FixedArrayHigh }
 func IsFixedString(c byte) bool { return c >= FixedStrLow && c <= FixedStrHigh }
+func IsExt(c byte) bool         { return c >= FixExtLow && c <= FixExtHigh || c >= ExtLow && c <= ExtHigh }
+func ExtSize(c byte) int {
+	switch c {
+	case Ext8:
+		return 1
+	case Ext16:
+		return 2
+	case Ext32:
+		return 4
+	}
+	return 0
+}

--- a/decode_map.go
+++ b/decode_map.go
@@ -76,7 +76,30 @@ func (d *Decoder) DecodeMapLen() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	if codes.IsExt(c) {
+		c, err = d.skipExtHeader(c)
+		if err != nil {
+			return 0, err
+		}
+	}
 	return d.mapLen(c)
+}
+
+func (d *Decoder) skipExtHeader(c byte) (byte, error) {
+	// skip type
+	_, err := d.r.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	// skip size
+	for i := 0; i < codes.ExtSize(c); i++ {
+		_, err := d.r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+	}
+	// read c again
+	return d.r.ReadByte()
 }
 
 func (d *Decoder) mapLen(c byte) (int, error) {

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -599,3 +599,22 @@ func (t *MsgpackTest) TestMapStringInterface2(c *C) {
 	mm := out["hello"].(map[string]interface{})
 	c.Assert(mm["foo"], Equals, "bar")
 }
+
+func TestDecodeExtWithMap(t *testing.T) {
+	type S struct {
+		I int
+	}
+	msgpack.RegisterExt(2, S{})
+	b, err := msgpack.Marshal(&S{I: 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := make(map[string]interface{})
+	if err := msgpack.Unmarshal(b, &v); err != nil {
+		t.Fatal(err)
+	}
+	ev := map[string]interface{}{"I": uint64(42)}
+	if !reflect.DeepEqual(v, ev) {
+		t.Fatalf("expect %#v but got %#v", ev, v)
+	}
+}


### PR DESCRIPTION
It is a convenient feature to decode any MsgPack map into a map[string]interface{} without specifying the exact Go type, but ext format is not supported yet, so here is a fix.