### PR TITLE
Add StrictMode to Decoder

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -41,6 +41,12 @@ func Unmarshal(b []byte, v ...interface{}) error {
 
 type Decoder struct {
 	DecodeMapFunc func(*Decoder) (interface{}, error)
+	/*
+	StrictMode: when the message have less
+		fileds than struct type, (omitEmpty fileds are not counted),
+		Decode() returns an error.
+	*/
+	StrictMode bool
 
 	r   bufReader
 	buf []byte

--- a/decode_map.go
+++ b/decode_map.go
@@ -200,12 +200,18 @@ func decodeStructValue(d *Decoder, strct reflect.Value) error {
 	if err != nil {
 		return err
 	}
+	fields := structs.Fields(strct.Type())
 	if n == -1 {
+		if d.StrictMode {
+			if fields.RequireFields > 0 {
+				return fmt.Errorf("msgpack: Decode(%s) missing required fields", strct.Type().Name())
+			}
+		}
 		strct.Set(reflect.Zero(strct.Type()))
 		return nil
 	}
 
-	fields := structs.Fields(strct.Type())
+	skipTimes := 0
 	for i := 0; i < n; i++ {
 		name, err := d.DecodeString()
 		if err != nil {
@@ -215,12 +221,21 @@ func decodeStructValue(d *Decoder, strct reflect.Value) error {
 			if err := f.DecodeValue(d, strct); err != nil {
 				return err
 			}
+			if f.omitEmpty {
+				skipTimes ++
+			}
 		} else {
 			if err := d.Skip(); err != nil {
 				return err
 			}
+			skipTimes ++
 		}
 	}
-
+	if d.StrictMode {
+		println(fields.RequireFields, n, skipTimes)
+		if fields.RequireFields != n - skipTimes {
+			return fmt.Errorf("msgpack: Decode(%s) missing required fields", strct.Type().Name())
+		}
+	}
 	return nil
 }

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -11,8 +11,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/vmihailenco/msgpack.v2"
-	"gopkg.in/vmihailenco/msgpack.v2/codes"
+	msgpack "./"
+	codes "./codes"
 )
 
 type nameStruct struct {
@@ -617,4 +617,43 @@ func TestDecodeExtWithMap(t *testing.T) {
 	if !reflect.DeepEqual(v, ev) {
 		t.Fatalf("expect %#v but got %#v", ev, v)
 	}
+}
+
+func TestDecodeStrictMode(t *testing.T) {
+	var err error
+	type A struct {
+		F1 int
+		F2 int
+		F3 int
+	}
+	a := A{1, 2, 3}
+	type B struct {
+		F1 int
+		F2 int `msgpack:",omitEmpty"`
+	}
+	b := B{}
+	buf, err := msgpack.Marshal(&a)
+	if err != nil {
+		t.Fatalf("marshal error :%v", err)
+	}
+	decoder := msgpack.NewDecoder(bytes.NewReader(buf))
+	decoder.StrictMode = true
+	err = decoder.Decode(&b)
+	if err != nil {
+		t.Fatalf("decode error :%v", err)
+	}
+	println("B:", b.F1, b.F2)
+	type C struct {
+		F1 int
+		F2 int `msgpack:",omitEmpty"`
+		F4 int
+	}
+	c := C{}
+	decoder = msgpack.NewDecoder(bytes.NewReader(buf))
+	decoder.StrictMode = true
+	err = decoder.Decode(&c)
+	if err == nil {
+		t.Fatal("expected error not occurred")
+	}
+	println(err.Error())
 }

--- a/types.go
+++ b/types.go
@@ -89,6 +89,7 @@ func (f *field) DecodeValue(d *Decoder, strct reflect.Value) error {
 type fields struct {
 	List  []*field
 	Table map[string]*field
+	RequireFields int
 
 	omitEmpty bool
 }
@@ -109,6 +110,8 @@ func (fs *fields) Add(field *field) {
 	fs.Table[field.name] = field
 	if field.omitEmpty {
 		fs.omitEmpty = field.omitEmpty
+	} else {
+		fs.RequireFields ++
 	}
 }
 


### PR DESCRIPTION
When decoder.StrictMode is set to true, and msgpack have less
fileds than struct type, (omitEmpty fileds are not counted),
decoder.Decode() returns an error.

I have added a test case for this , TestDecodeStrictMode