### PR TITLE
Export EncodeBytesLen() as part of the encoder API

### DIFF
--- a/encode_slice.go
+++ b/encode_slice.go
@@ -15,7 +15,7 @@ func encodeByteSliceValue(e *Encoder, v reflect.Value) error {
 }
 
 func encodeByteArrayValue(e *Encoder, v reflect.Value) error {
-	if err := e.encodeBytesLen(v.Len()); err != nil {
+	if err := e.EncodeBytesLen(v.Len()); err != nil {
 		return err
 	}
 
@@ -29,7 +29,7 @@ func encodeByteArrayValue(e *Encoder, v reflect.Value) error {
 	return e.write(b)
 }
 
-func (e *Encoder) encodeBytesLen(l int) error {
+func (e *Encoder) EncodeBytesLen(l int) error {
 	if l < 256 {
 		return e.write1(codes.Bin8, uint64(l))
 	}
@@ -63,7 +63,7 @@ func (e *Encoder) EncodeBytes(v []byte) error {
 	if v == nil {
 		return e.EncodeNil()
 	}
-	if err := e.encodeBytesLen(len(v)); err != nil {
+	if err := e.EncodeBytesLen(len(v)); err != nil {
 		return err
 	}
 	return e.write(v)


### PR DESCRIPTION
This PR exports EncodeBytesLen() as part of the encoder API to enable zero-copy encoding of multiple byte slices.

Fixes #119 