### PR TITLE
Fallback to json struct tag if no msgpack tag is present

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -226,7 +226,7 @@ func decodeStructValue(d *Decoder, strct reflect.Value) error {
 		return nil
 	}
 
-	fields := structs.Fields(strct.Type())
+	fields := structs.Fields(strct.Type(), false)
 
 	if isArray {
 		for i, f := range fields.List {

--- a/encode.go
+++ b/encode.go
@@ -41,6 +41,7 @@ type Encoder struct {
 
 	sortMapKeys   bool
 	structAsArray bool
+	useJSONTag    bool
 }
 
 func NewEncoder(w io.Writer) *Encoder {
@@ -66,6 +67,12 @@ func (e *Encoder) SortMapKeys(v bool) *Encoder {
 // StructAsArray causes the Encoder to encode Go structs as MessagePack arrays.
 func (e *Encoder) StructAsArray(v bool) *Encoder {
 	e.structAsArray = v
+	return e
+}
+
+// UseJSONTag causes the Encoder to use json struct tags.
+func (e *Encoder) UseJSONTag(v bool) *Encoder {
+	e.useJSONTag = v
 	return e
 }
 

--- a/encode_map.go
+++ b/encode_map.go
@@ -131,7 +131,7 @@ func (e *Encoder) EncodeMapLen(l int) error {
 }
 
 func encodeStructValue(e *Encoder, strct reflect.Value) error {
-	structFields := structs.Fields(strct.Type())
+	structFields := structs.Fields(strct.Type(), e.useJSONTag)
 	if e.structAsArray || structFields.asArray {
 		return encodeStructValueAsArray(e, strct, structFields.List)
 	}


### PR DESCRIPTION
This change is related to #149 and adds fallback option to `json:`
struct tags if no `msgpack:` tags are found. This is useful if you want
to serialize a generated struct that already has the `json:` tags and you
want to `msgpack` it as well. Sure, it can be abused, but I think it's
common enough and may help people transition to `msgpack` when they need
it.

I need this in my current project and this seems to work okay for us.
That said, I can understand your concerns if you don't want to support
it.