### PR TITLE
Improve performance by directly allocating buffer without appending when buffer is nil

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -487,7 +487,11 @@ func readN(r io.Reader, b []byte, n int) ([]byte, error) {
 		if diff > bytesAllocLimit {
 			diff = bytesAllocLimit
 		}
-		b = append(b, make([]byte, diff)...)
+		if b == nil {
+			b = make([]byte, diff)
+		} else {
+			b = append(b, make([]byte, diff)...)
+		}
 
 		_, err := io.ReadFull(r, b[pos:])
 		if err != nil {


### PR DESCRIPTION
This PR adds logic to directly allocate buffer instead of appending when the buffer passed into `readN` is nil to improve performance. Specifically when decoding a byte slice, a nil buffer is passed in to `readN`, so appending bytes would result in a large number of copying and reallocations when the byte slice is large (but not larger than `bytesAllocLimit`), causing performance degradations. This PR adds a shortcut to address that case for performance improvement. 