### PR TITLE
Eliminate unnecessary interface conversions to improve performance

### DIFF
--- a/time.go
+++ b/time.go
@@ -85,7 +85,7 @@ func (d *Decoder) decodeTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	_, err = d.r.ReadByte()
+	_, err = d.s.ReadByte()
 	if err != nil {
 		return time.Time{}, nil
 	}


### PR DESCRIPTION
This PR splits the original reader (`bufReader`) into an `io.Reader` and an `io.ByteScanner` to eliminate unnecessary interface conversions for improved performance and memory profile. An example use case is when decoding a slice of values (e.g., int/float64/etc), `readN` is called repeatedly in a tight loop incurring the interface conversion overhead in each call. With this change the performance of decoding such slices has improved by ~30%.