### PR TITLE
Fallback to json struct tag if no msgpack tag is present

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -44,7 +44,8 @@ type Decoder struct {
 	extLen int
 	rec    []byte // accumulates read data if not nil
 
-	useLoose bool
+	useLoose   bool
+	useJSONTag bool
 
 	decodeMapFunc func(*Decoder) (interface{}, error)
 }
@@ -72,6 +73,13 @@ func (d *Decoder) SetDecodeMapFunc(fn func(*Decoder) (interface{}, error)) {
 // to decode msgpack value into Go interface{}.
 func (d *Decoder) UseDecodeInterfaceLoose(flag bool) {
 	d.useLoose = flag
+}
+
+// UseJSONTag causes the Decoder to use json struct tag as fallback option
+// if there is no msgpack tag.
+func (d *Decoder) UseJSONTag(v bool) *Decoder {
+	d.useJSONTag = v
+	return d
 }
 
 func (d *Decoder) Reset(r io.Reader) error {

--- a/decode_map.go
+++ b/decode_map.go
@@ -244,7 +244,12 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type())
+	var fields *fields
+	if d.useJSONTag {
+		fields = jsonStructs.Fields(v.Type())
+	} else {
+		fields = structs.Fields(v.Type())
+	}
 
 	if isArray {
 		for i, f := range fields.List {

--- a/encode.go
+++ b/encode.go
@@ -55,6 +55,7 @@ type Encoder struct {
 
 	sortMapKeys   bool
 	structAsArray bool
+	useJSONTag    bool
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -81,6 +82,13 @@ func (e *Encoder) SortMapKeys(v bool) *Encoder {
 // StructAsArray causes the Encoder to encode Go structs as MessagePack arrays.
 func (e *Encoder) StructAsArray(v bool) *Encoder {
 	e.structAsArray = v
+	return e
+}
+
+// UseJSONTag causes the Encoder to use json struct tag as fallback option
+// if there is no msgpack tag.
+func (e *Encoder) UseJSONTag(v bool) *Encoder {
+	e.useJSONTag = v
 	return e
 }
 

--- a/encode_map.go
+++ b/encode_map.go
@@ -131,8 +131,14 @@ func (e *Encoder) EncodeMapLen(l int) error {
 }
 
 func encodeStructValue(e *Encoder, strct reflect.Value) error {
-	structFields := structs.Fields(strct.Type())
-	if e.structAsArray || structFields.asArray {
+	var structFields *fields
+	if e.useJSONTag {
+		structFields = jsonStructs.Fields(strct.Type())
+	} else {
+		structFields = structs.Fields(strct.Type())
+	}
+
+	if e.structAsArray || structFields.AsArray {
 		return encodeStructValueAsArray(e, strct, structFields.List)
 	}
 	fields := structFields.OmitEmpty(strct)


### PR DESCRIPTION
This change is related to #149 and adds fallback option to `json:`
struct tags if no `msgpack:` tags are found. This is useful if you want
to serialize a generate struct that already has the `json:` tags and you
want to `msgpack` it as well.

To enable the `json:` tag fallback set `Encoder.UseJSONTag(true)`.