### PR TITLE
Don't autoinline struct fields if there are name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.3
+
+- `msgpack:",inline"` tag is restored to force inlining structs.
+
 ## v3.2
 
 - Decoding extension types returns pointer to the value instead of the value. Fixes #153

--- a/types_test.go
+++ b/types_test.go
@@ -136,6 +136,17 @@ type InlinePtrTest struct {
 	*OmitEmptyTest
 }
 
+type FooTest struct {
+	Foo string
+}
+
+type FooDupTest FooTest
+
+type InlineDupTest struct {
+	FooTest
+	FooDupTest
+}
+
 type AsArrayTest struct {
 	_msgpack struct{} `msgpack:",asArray"`
 
@@ -445,6 +456,17 @@ var (
 		{in: &ExtTest{"world"}, out: new(ExtTest), wanted: ExtTest{"hello world"}},
 
 		{in: Interface{}, out: &Interface{Foo: "bar"}},
+
+		{
+			in:  &InlineTest{OmitEmptyTest: OmitEmptyTest{Bar: "world"}},
+			out: new(InlineTest),
+		}, {
+			in:  &InlinePtrTest{OmitEmptyTest: &OmitEmptyTest{Bar: "world"}},
+			out: new(InlinePtrTest),
+		}, {
+			in:  InlineDupTest{FooTest{"foo"}, FooDupTest{"foo dup"}},
+			out: new(InlineDupTest),
+		},
 	}
 )
 


### PR DESCRIPTION
Replaces https://github.com/vmihailenco/msgpack/pull/175