### PR TITLE
Add Canonical option to encoder

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -56,6 +56,7 @@ type Encoder struct {
 	sortMapKeys   bool
 	structAsArray bool
 	useJSONTag    bool
+	canonical     bool
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -74,8 +75,22 @@ func NewEncoder(w io.Writer) *Encoder {
 // Supported map types are:
 //   - map[string]string
 //   - map[string]interface{}
+// SortMapKeys and Canonical are exclusive. Canonical flag takes precedence.
 func (e *Encoder) SortMapKeys(v bool) *Encoder {
 	e.sortMapKeys = v
+	return e
+}
+
+// Canonical causes the Encoder to encode map keys and structs in increasing order.
+// This flag ensures same encoding for all the maps of any kind as well as structs
+// (For structs, the field name is used for ordering).
+// SortMapKeys and Canonical are exclusive. Canonical flag takes precedence.
+// As a result of using this flag, the two types map[string]string and map[string]interface{}
+// will be ordered as well, but the ordering done by this flag might differ from the one done
+// by the flag SortMapKeys.
+// Setting this flag to true might have an important impact on speed and memory usage.
+func (e *Encoder) Canonical(v bool) *Encoder {
+	e.canonical = v
 	return e
 }
 

--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,226 @@
+package msgpack
+
+import "bytes"
+
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+func insertionSort(data [][]byte, a, b int) {
+	for i := a + 1; i < b; i++ {
+		for j := i; j > a && bytes.Compare(data[j], data[j-1]) < 0; j-- {
+			data[j], data[j-1] = data[j-1], data[j]
+		}
+	}
+}
+
+// siftDown implements the heap property on data[lo, hi).
+// first is an offset into the array where the root of the heap lies.
+func siftDown(data [][]byte, lo, hi, first int) {
+	root := lo
+	for {
+		child := 2*root + 1
+		if child >= hi {
+			break
+		}
+		if child+1 < hi && bytes.Compare(data[first+child], data[first+child+1]) < 0 {
+			child++
+		}
+		if bytes.Compare(data[first+root], data[first+child]) >= 0 {
+			return
+		}
+		data[first+root], data[first+child] = data[first+child], data[first+root]
+		root = child
+	}
+}
+
+func heapSort(data [][]byte, a, b int) {
+	first := a
+	lo := 0
+	hi := b - a
+
+	// Build heap with greatest element at top.
+	for i := (hi - 1) / 2; i >= 0; i-- {
+		siftDown(data, i, hi, first)
+	}
+
+	// Pop elements, largest first, into end of data.
+	for i := hi - 1; i >= 0; i-- {
+		data[first], data[first+i] = data[first+i], data[first]
+		siftDown(data, lo, i, first)
+	}
+}
+
+// medianOfThree moves the median of the three values data[m0], data[m1], data[m2] into data[m1].
+func medianOfThree(data [][]byte, m1, m0, m2 int) {
+	// sort 3 elements
+	if bytes.Compare(data[m1], data[m0]) < 0 {
+		data[m1], data[m0] = data[m0], data[m1]
+	}
+	// data[m0] <= data[m1]
+	if bytes.Compare(data[m2], data[m1]) < 0 {
+		data[m2], data[m1] = data[m1], data[m2]
+		// data[m0] <= data[m2] && data[m1] < data[m2]
+		if bytes.Compare(data[m1], data[m0]) < 0 {
+			data[m1], data[m0] = data[m0], data[m1]
+		}
+	}
+	// now data[m0] <= data[m1] <= data[m2]
+}
+
+func doPivot(data [][]byte, lo, hi int) (midlo, midhi int) {
+	m := int(uint(lo+hi) >> 1) // Written like this to avoid integer overflow.
+	if hi-lo > 40 {
+		// Tukey's ``Ninther,'' median of three medians of three.
+		s := (hi - lo) / 8
+		medianOfThree(data, lo, lo+s, lo+2*s)
+		medianOfThree(data, m, m-s, m+s)
+		medianOfThree(data, hi-1, hi-1-s, hi-1-2*s)
+	}
+	medianOfThree(data, lo, m, hi-1)
+
+	// Invariants are:
+	//	data[lo] = pivot (set up by ChoosePivot)
+	//	data[lo < i < a] < pivot
+	//	data[a <= i < b] <= pivot
+	//	data[b <= i < c] unexamined
+	//	data[c <= i < hi-1] > pivot
+	//	data[hi-1] >= pivot
+	pivot := lo
+	a, c := lo+1, hi-1
+
+	for ; a < c && bytes.Compare(data[a], data[pivot]) < 0; a++ {
+	}
+	b := a
+	for {
+		for ; b < c && bytes.Compare(data[pivot], data[b]) >= 0; b++ { // data[b] <= pivot
+		}
+		for ; b < c && bytes.Compare(data[pivot], data[c-1]) < 0; c-- { // data[c-1] > pivot
+		}
+		if b >= c {
+			break
+		}
+		// data[b] > pivot; data[c-1] <= pivot
+		data[b], data[c-1] = data[c-1], data[b]
+		b++
+		c--
+	}
+	// If hi-c<3 then there are duplicates (by property of median of nine).
+	// Let be a bit more conservative, and set border to 5.
+	protect := hi-c < 5
+	if !protect && hi-c < (hi-lo)/4 {
+		// Lets test some points for equality to pivot
+		dups := 0
+		if bytes.Compare(data[pivot], data[hi-1]) >= 0 { // data[hi-1] = pivot
+			data[c], data[hi-1] = data[hi-1], data[c]
+			c++
+			dups++
+		}
+		if bytes.Compare(data[b-1], data[pivot]) >= 0 { // data[b-1] = pivot
+			b--
+			dups++
+		}
+		// m-lo = (hi-lo)/2 > 6
+		// b-lo > (hi-lo)*3/4-1 > 8
+		// ==> m < b ==> data[m] <= pivot
+		if bytes.Compare(data[m], data[pivot]) >= 0 { // data[m] = pivot
+			data[m], data[b-1] = data[b-1], data[m]
+			b--
+			dups++
+		}
+		// if at least 2 points are equal to pivot, assume skewed distribution
+		protect = dups > 1
+	}
+	if protect {
+		// Protect against a lot of duplicates
+		// Add invariant:
+		//	data[a <= i < b] unexamined
+		//	data[b <= i < c] = pivot
+		for {
+			for ; a < b && bytes.Compare(data[b-1], data[pivot]) >= 0; b-- { // data[b] == pivot
+			}
+			for ; a < b && bytes.Compare(data[a], data[pivot]) < 0; a++ { // data[a] < pivot
+			}
+			if a >= b {
+				break
+			}
+			// data[a] == pivot; data[b-1] < pivot
+			data[a], data[b-1] = data[b-1], data[a]
+			a++
+			b--
+		}
+	}
+	// Swap pivot into middle
+	data[pivot], data[b-1] = data[b-1], data[pivot]
+	return b - 1, c
+}
+
+func quickSort(data [][]byte, a, b, maxDepth int) {
+	for b-a > 12 { // Use ShellSort for slices <= 12 elements
+		if maxDepth == 0 {
+			heapSort(data, a, b)
+			return
+		}
+		maxDepth--
+		mlo, mhi := doPivot(data, a, b)
+		// Avoiding recursion on the larger subproblem guarantees
+		// a stack depth of at most lg(b-a).
+		if mlo-a < b-mhi {
+			quickSort(data, a, mlo, maxDepth)
+			a = mhi // i.e., quickSort(data, mhi, b)
+		} else {
+			quickSort(data, mhi, b, maxDepth)
+			b = mlo // i.e., quickSort(data, a, mlo)
+		}
+	}
+	if b-a > 1 {
+		// Do ShellSort pass with gap 6
+		// It could be written in this simplified form cause b-a <= 12
+		for i := a + 6; i < b; i++ {
+			if bytes.Compare(data[i], data[i-6]) < 0 {
+				data[i], data[i-6] = data[i-6], data[i]
+			}
+		}
+		insertionSort(data, a, b)
+	}
+}
+
+// maxDepth returns a threshold at which quicksort should switch
+// to heapsort. It returns 2*ceil(lg(n+1)).
+func maxDepth(n int) int {
+	var depth int
+	for i := n; i > 0; i >>= 1 {
+		depth++
+	}
+	return depth * 2
+}
+
+func sortBytesArray(a [][]byte) {
+	// sort.Sort(sortByteArray(a))
+	n := len(a)
+	quickSort(a, 0, n, maxDepth(n))
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,170 @@
+package msgpack
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestSort(t *testing.T) {
+	tests := []struct {
+		in  [][]byte
+		out [][]byte
+	}{
+		{
+			in:  nil,
+			out: nil,
+		},
+		{
+			in: [][]byte{
+				[]byte{},
+			},
+			out: [][]byte{
+				[]byte{},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{},
+				[]byte{},
+			},
+			out: [][]byte{
+				[]byte{},
+				[]byte{},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{1},
+				[]byte{1},
+			},
+			out: [][]byte{
+				[]byte{1},
+				[]byte{1},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{1, 1},
+				[]byte{1},
+			},
+			out: [][]byte{
+				[]byte{1},
+				[]byte{1, 1},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{1},
+				[]byte{1, 1},
+			},
+			out: [][]byte{
+				[]byte{1},
+				[]byte{1, 1},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{1, 2},
+				[]byte{1, 1},
+			},
+			out: [][]byte{
+				[]byte{1, 1},
+				[]byte{1, 2},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{1, 1},
+				[]byte{1, 2},
+			},
+			out: [][]byte{
+				[]byte{1, 1},
+				[]byte{1, 2},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{1, 1, 1},
+				[]byte{1, 2, 3},
+				[]byte{1, 1, 3},
+			},
+			out: [][]byte{
+				[]byte{1, 1, 1},
+				[]byte{1, 1, 3},
+				[]byte{1, 2, 3},
+			},
+		},
+		{
+			in: [][]byte{
+				[]byte{1, 1, 1},
+				[]byte{1, 2, 3},
+				[]byte{1, 1, 3},
+				[]byte{3, 1, 3},
+				[]byte{4, 1, 3},
+				[]byte{9, 1, 3},
+				[]byte{6, 1, 3},
+				[]byte{2, 1, 3},
+				[]byte{7, 1, 3},
+				[]byte{1, 4, 3},
+				[]byte{1, 78, 3},
+				[]byte{1, 32, 3},
+				[]byte{1, 14, 3},
+			},
+			out: [][]byte{
+				[]byte{1, 1, 1},
+				[]byte{1, 1, 3},
+				[]byte{1, 2, 3},
+				[]byte{1, 4, 3},
+				[]byte{1, 14, 3},
+				[]byte{1, 32, 3},
+				[]byte{1, 78, 3},
+				[]byte{2, 1, 3},
+				[]byte{3, 1, 3},
+				[]byte{4, 1, 3},
+				[]byte{6, 1, 3},
+				[]byte{7, 1, 3},
+				[]byte{9, 1, 3},
+			},
+		},
+	}
+
+	for i, tcase := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			sortBytesArray(tcase.in)
+			if len(tcase.out) != len(tcase.in) {
+				t.Fatalf("Error sorting. Invalid length (%d vs %d", len(tcase.out), len(tcase.in))
+			}
+			for i := range tcase.in {
+				if bytes.Compare(tcase.in[i], tcase.out[i]) != 0 {
+					t.Fatalf("Error sorting. Different data at pos %d", i)
+				}
+			}
+		})
+	}
+}
+
+var unsorted = [][]byte{
+	[]byte{24, 3, 4, 2, 3},
+	[]byte{1, 2, 3, 4, 5},
+	[]byte{2, 5, 6, 2, 3},
+	[]byte{8, 4, 5, 7, 8},
+	[]byte{8, 4, 5, 7, 7},
+	[]byte{8, 4, 5, 7, 9},
+	[]byte{7, 4, 6, 7, 8, 9, 24, 35},
+	[]byte{7, 4, 6, 7, 8, 9, 24, 36},
+	[]byte{7, 4, 6, 7, 8, 9, 24, 37},
+	[]byte{7, 4, 6, 7, 8, 9, 24, 39},
+	[]byte{1, 2, 3},
+	[]byte{1, 2, 3, 89},
+}
+
+func BenchmarkMarshalSort(b *testing.B) {
+	data := make([][]byte, len(unsorted))
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		copy(data, unsorted)
+		sortBytesArray(data)
+	}
+}


### PR DESCRIPTION
Encoded values can be used as keys by external systems.
It is the case when the encoded value is used for caching or as a
primary key in a DB.
In order to be able to use msgpack encoded value as a key, we must
ensure that the generated byte array is always the same for the same
input.
This is important for maps and structs.
For maps, as they are unordered, ordering must be added to the resulting
encoded value.
For slices, as they are serialized as maps, they must conform to the
same ordering as maps.

This change is adding a Canonical option to the Encoder.
When this option is enabled, the Encoder ensures ordering or maps and
structs so they can be used as keys.