### PR TITLE
parseTag incorrectly splits on semicolon

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -28,15 +28,8 @@ func (o tagOptions) Contains(name string) bool {
 }
 
 func parseTag(tag string) (string, tagOptions) {
-	if idx := strings.IndexByte(tag, ','); idx != -1 {
-		name := tag[:idx]
-		if strings.IndexByte(name, ':') == -1 {
-			return name, tagOptions(tag[idx+1:])
-		}
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
 	}
-
-	if strings.IndexByte(tag, ':') == -1 {
-		return tag, ""
-	}
-	return "", tagOptions(tag)
+	return tag, tagOptions("")
 }


### PR DESCRIPTION
Hi @vmihailenco,

We have struct tag with `msgpack:"foo:bar,omitempty"` and the string doesn't unmarshal into it because the parseTag splits it incorrectly. I have ported https://golang.org/src/encoding/json/tags.go#L17 back which works correctly. You can edit my PR for adding an extra OmitEmpty unit test for types. 

Kind regards,
Jerry