### PR TITLE
fix panic during *error encoding

### DIFF
--- a/encode_value.go
+++ b/encode_value.go
@@ -156,7 +156,7 @@ func encodeInterfaceValue(e *Encoder, v reflect.Value) error {
 }
 
 func encodeErrorValue(e *Encoder, v reflect.Value) error {
-	if v.IsNil() {
+	if v.IsNil() || !v.CanInterface() {
 		return e.EncodeNil()
 	}
 	return e.EncodeString(v.Interface().(error).Error())


### PR DESCRIPTION
See the interfaceEmbedder test case, which formerly would cause reflect to panic.