### PR TITLE
fix DecodeInterfaceLoose() in decoding negative fixint

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -350,7 +350,7 @@ func (d *Decoder) DecodeInterfaceLoose() (interface{}, error) {
 	}
 
 	if codes.IsFixedNum(c) {
-		return int64(c), nil
+		return int64(int8(c)), nil
 	}
 	if codes.IsFixedMap(c) {
 		err = d.s.UnreadByte()


### PR DESCRIPTION
DecodeInterfaceLoose()  will generate a wrong number in decoding negative fixint.