### PR TITLE
add an option to decode all times to UTC instead of local timezone

### DIFF
--- a/ext_test.go
+++ b/ext_test.go
@@ -202,6 +202,23 @@ func TestSliceOfTime(t *testing.T) {
 	if outTime.Unix() != inTime.Unix() {
 		t.Fatalf("got %v, wanted %v", outTime, inTime)
 	}
+	if outTime.Location() != inTime.Location() {
+		t.Fatalf("got %v, wanted %v", outTime.Location(), inTime.Location())
+	}
+
+	msgpack.DecodeTimeInUTC = true
+	err = msgpack.Unmarshal(b, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outTime = *out[0].(*time.Time)
+	if outTime.Unix() != inTime.Unix() {
+		t.Fatalf("got %v, wanted %v", outTime, inTime)
+	}
+	if outTime.Location() != time.UTC {
+		t.Fatalf("got %v, wanted %v", outTime.Location(), inTime.Location())
+	}
+	msgpack.DecodeTimeInUTC = false
 }
 
 type customPayload struct {

--- a/time.go
+++ b/time.go
@@ -10,6 +10,7 @@ import (
 )
 
 var timeExtID int8 = -1
+var DecodeTimeInUTC bool
 
 //nolint:gochecknoinits
 func init() {
@@ -143,6 +144,9 @@ func decodeTimeValue(d *Decoder, v reflect.Value) error {
 	tm, err := d.DecodeTime()
 	if err != nil {
 		return err
+	}
+	if DecodeTimeInUTC {
+		tm = tm.UTC()
 	}
 	v.Set(reflect.ValueOf(tm))
 	return nil


### PR DESCRIPTION
Since the msgpack standard doesn't include timezone information, decoded times are created in the local location. This can make it hard to write deterministic tests and otherwise account for whatever the local location might be.

This PR just adds a simple bool that causes all decoded times to be in UTC, to make it much easier to work with.