### PR TITLE
Allow floating point numbers to use a compact representation.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -72,10 +72,11 @@ type Encoder struct {
 
 	intern map[string]int
 
-	sortMapKeys   bool
-	structAsArray bool
-	useJSONTag    bool
-	useCompact    bool
+	sortMapKeys   	 bool
+	structAsArray 	 bool
+	useJSONTag    	 bool
+	useCompact    	 bool
+	useCompactFloats bool
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -133,6 +134,13 @@ func (e *Encoder) UseJSONTag(flag bool) *Encoder {
 // For example, it allows to encode small Go int64 as msgpack int8 saving 7 bytes.
 func (e *Encoder) UseCompactEncoding(flag bool) *Encoder {
 	e.useCompact = flag
+	return e
+}
+
+// UseCompactFloats causes the Encoder to chose a compact integer encoding for integer floating
+// point values.
+func (e *Encoder) UseCompactFloatEncoding(flag bool) *Encoder {
+	e.useCompactFloats = flag
 	return e
 }
 

--- a/encode_number.go
+++ b/encode_number.go
@@ -143,10 +143,24 @@ func (e *Encoder) EncodeInt(n int64) error {
 }
 
 func (e *Encoder) EncodeFloat32(n float32) error {
+	if e.useCompactFloats {
+		if float32(int64(n)) == n {
+			return e.EncodeInt(int64(n))
+		}
+	}
 	return e.write4(codes.Float, math.Float32bits(n))
 }
 
 func (e *Encoder) EncodeFloat64(n float64) error {
+	if e.useCompactFloats {
+		// Both NaN and Inf convert to int64(-0x8000000000000000)
+		// If n is NaN then it never compares true with any other value
+		// If n is Inf then it doesn't convert from int64 back to +/-Inf
+		// In both cases the comparison works.
+		if float64(int64(n)) == n {
+			return e.EncodeInt(int64(n))
+		}
+	}
 	return e.write8(codes.Double, math.Float64bits(n))
 }
 


### PR DESCRIPTION
If a float32/64 is an integer and representable in int64 then use a compact integer encoding.