### PR TITLE
Add the ability to use custom struct tags as fallback

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	looseIfaceFlag uint32 = 1 << iota
-	decodeUsingJSONFlag
 	disallowUnknownFieldsFlag
 )
 
@@ -74,6 +73,7 @@ type Decoder struct {
 
 	intern        []string
 	flags         uint32
+	structTag     string
 	decodeMapFunc func(*Decoder) (interface{}, error)
 }
 
@@ -84,6 +84,7 @@ type Decoder struct {
 // by passing a reader that implements io.ByteScanner interface.
 func NewDecoder(r io.Reader) *Decoder {
 	d := new(Decoder)
+	d.structTag = defaultStructTag
 	d.Reset(r)
 	return d
 }
@@ -139,11 +140,17 @@ func (d *Decoder) UseDecodeInterfaceLoose(on bool) {
 // UseJSONTag causes the Decoder to use json struct tag as fallback option
 // if there is no msgpack tag.
 func (d *Decoder) UseJSONTag(on bool) {
+	tag := defaultStructTag
 	if on {
-		d.flags |= decodeUsingJSONFlag
-	} else {
-		d.flags &= ^decodeUsingJSONFlag
+		tag = "json"
 	}
+	d.UseCustomStructTag(tag)
+}
+
+// UseCustomStructTag causes the decoder to use the supplied tag as a fallback option
+// if there is no msgpack tag.
+func (d *Decoder) UseCustomStructTag(tag string) {
+	d.structTag = tag
 }
 
 // DisallowUnknownFields causes the Decoder to return an error when the destination

--- a/decode_map.go
+++ b/decode_map.go
@@ -293,13 +293,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 		return nil
 	}
 
-	var fields *fields
-	if d.flags&decodeUsingJSONFlag != 0 {
-		fields = jsonStructs.Fields(v.Type())
-	} else {
-		fields = structs.Fields(v.Type())
-	}
-
+	fields := structs.Fields(d.structTag, v.Type())
 	if isArray {
 		for i, f := range fields.List {
 			if i >= n {

--- a/encode.go
+++ b/encode.go
@@ -13,7 +13,6 @@ import (
 const (
 	sortMapKeysFlag uint32 = 1 << iota
 	structAsArrayFlag
-	encodeUsingJSONFlag
 	useCompactIntsFlag
 	useCompactFloatsFlag
 )
@@ -88,7 +87,8 @@ type Encoder struct {
 
 	intern map[string]int
 
-	flags uint32
+	flags     uint32
+	structTag string
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -96,6 +96,7 @@ func NewEncoder(w io.Writer) *Encoder {
 	e := &Encoder{
 		buf: make([]byte, 9),
 	}
+	e.structTag = defaultStructTag
 	e.Reset(w)
 	return e
 }
@@ -146,11 +147,17 @@ func (e *Encoder) StructAsArray(on bool) {
 // UseJSONTag causes the Encoder to use json struct tag as fallback option
 // if there is no msgpack tag.
 func (e *Encoder) UseJSONTag(on bool) {
+	tag := defaultStructTag
 	if on {
-		e.flags |= encodeUsingJSONFlag
-	} else {
-		e.flags &= ^encodeUsingJSONFlag
+		tag = "json"
 	}
+	e.UseCustomStructTag(tag)
+}
+
+// UseCustomStructTag causes the Encoder to use a custom struct tag as
+// fallback option if there is no msgpack tag.
+func (e *Encoder) UseCustomStructTag(tag string) {
+	e.structTag = tag
 }
 
 // UseCompactEncoding causes the Encoder to chose the most compact encoding.

--- a/encode_map.go
+++ b/encode_map.go
@@ -131,13 +131,7 @@ func (e *Encoder) EncodeMapLen(l int) error {
 }
 
 func encodeStructValue(e *Encoder, strct reflect.Value) error {
-	var structFields *fields
-	if e.flags&encodeUsingJSONFlag != 0 {
-		structFields = jsonStructs.Fields(strct.Type())
-	} else {
-		structFields = structs.Fields(strct.Type())
-	}
-
+	structFields := structs.Fields(e.structTag, strct.Type())
 	if e.flags&structAsArrayFlag != 0 || structFields.AsArray {
 		return encodeStructValueAsArray(e, strct, structFields.List)
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -146,6 +146,40 @@ func TestUseJsonTag(t *testing.T) {
 
 //------------------------------------------------------------------------------
 
+type CustomFallbackTest struct {
+	Foo string `custom:"foo,omitempty"`
+	Bar string `custom:",omitempty" msgpack:"bar"`
+}
+
+func TestUseCustomTag(t *testing.T) {
+	var buf bytes.Buffer
+
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCustomStructTag("custom")
+	in := &CustomFallbackTest{Foo: "hello", Bar: "world"}
+	err := enc.Encode(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := msgpack.NewDecoder(&buf)
+	dec.UseCustomStructTag("custom")
+	out := new(CustomFallbackTest)
+	err = dec.Decode(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Foo != in.Foo || out.Foo != "hello" {
+		t.Fatalf("got %q, wanted %q", out.Foo, in.Foo)
+	}
+	if out.Bar != in.Bar || out.Bar != "world" {
+		t.Fatalf("got %q, wanted %q", out.Foo, in.Foo)
+	}
+}
+
+//------------------------------------------------------------------------------
+
 type OmitEmptyTest struct {
 	Foo string `msgpack:",omitempty"`
 	Bar string `msgpack:",omitempty"`


### PR DESCRIPTION
The ability to use JSON struct tags as a fallback for structs that do
not implement msgpack tags directly is nice. This extends the ability
to any struct tag and allows msgpack to be used in place of other
similar encoding schemes.