### PR TITLE
Backport v4 Issue260: Prevent panic if map key is not comparable.

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -187,6 +187,8 @@ func (d *Decoder) decodeMapStringInterfacePtr(ptr *map[string]interface{}) error
 	return nil
 }
 
+var errUnsupportedMapKey = errors.New("msgpack: unsupported map key")
+
 func (d *Decoder) DecodeMap() (interface{}, error) {
 	if d.decodeMapFunc != nil {
 		return d.decodeMapFunc(d)
@@ -224,6 +226,10 @@ func (d *Decoder) DecodeMap() (interface{}, error) {
 
 	keyType := reflect.TypeOf(key)
 	valueType := reflect.TypeOf(value)
+
+	if !keyType.Comparable() {
+		return nil, errUnsupportedMapKey
+	}
 
 	mapType := reflect.MapOf(keyType, valueType)
 	mapValue := reflect.MakeMap(mapType)

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -272,3 +272,16 @@ func (t *MsgpackTest) TestMapStringInterface(c *C) {
 	mm := out["hello"].(map[string]interface{})
 	c.Assert(mm["foo"], Equals, "bar")
 }
+
+//------------------------------------------------------------------------------
+
+func TestNoPanicOnUnsupportKey(t *testing.T) {
+	data := []byte{0x81, 0x81, 0xa1, 0x78, 0xc3, 0xc3}
+
+	var msg interface{}
+	err := msgpack.Unmarshal(data, &msg)
+
+	if err == nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Backport to v4 change to avoid panic.