### PR TITLE
Fix escaping field labels

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -208,9 +208,9 @@ func ExampleMarshal_escapedNames() {
 		panic(err)
 	}
 
-	type Item struct{
-		SomethingSpecial uint `msgpack:"'something:special'"`
-		HelloWorld string     `msgpack:"'hello, world'"`
+	type Item struct {
+		SomethingSpecial uint   `msgpack:"'something:special'"`
+		HelloWorld       string `msgpack:"'hello, world'"`
 	}
 	var item Item
 	if err := msgpack.Unmarshal(raw, &item); err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -197,3 +197,25 @@ func ExampleMarshal_omitEmpty() {
 	// Output: item: "\x82\xa3Foo\xa5hello\xa3Bar\xa0"
 	// item2: "\x81\xa3Foo\xa5hello"
 }
+
+func ExampleMarshal_escapedNames() {
+	og := map[string]interface{}{
+		"something:special": uint(123),
+		"hello, world":      "hello!",
+	}
+	raw, err := msgpack.Marshal(og)
+	if err != nil {
+		panic(err)
+	}
+
+	type Item struct{
+		SomethingSpecial uint `msgpack:"'something:special'"`
+		HelloWorld string     `msgpack:"'hello, world'"`
+	}
+	var item Item
+	if err := msgpack.Unmarshal(raw, &item); err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v\n", item)
+	//output: msgpack_test.Item{SomethingSpecial:0x7b, HelloWorld:"hello!"}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,6 @@ require (
 	github.com/vmihailenco/tagparser v0.1.2
 )
 
+replace github.com/vmihailenco/tagparser v0.1.2 => github.com/mthjs/tagparser v0.2.0
+
 go 1.11

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,7 @@ module github.com/vmihailenco/msgpack/v5
 
 require (
 	github.com/stretchr/testify v1.6.1
-	github.com/vmihailenco/tagparser v0.1.2
+	github.com/vmihailenco/tagparser/v2 v2.0.0
 )
-
-replace github.com/vmihailenco/tagparser v0.1.2 => github.com/mthjs/tagparser v0.2.0
 
 go 1.11

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,12 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mthjs/tagparser v0.2.0 h1:vgTNs5z15+S4ZwmnEV6/HlC05MaAVEfIu4IoBdKH/B8=
-github.com/mthjs/tagparser v0.2.0/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
-github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mthjs/tagparser v0.2.0 h1:vgTNs5z15+S4ZwmnEV6/HlC05MaAVEfIu4IoBdKH/B8=
+github.com/mthjs/tagparser v0.2.0/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/types.go
+++ b/types.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/vmihailenco/tagparser"
+	"github.com/vmihailenco/tagparser/v2"
 )
 
 var errorType = reflect.TypeOf((*error)(nil)).Elem()


### PR DESCRIPTION
As mentioned in #296, it unmarshalling msgpacked data into a field with a colon in its label didn't work as expected. Quoted field labels aren't properly matched. As discussed in https://github.com/vmihailenco/tagparser/pull/4, this was caused due to the quoted tags/labels not being unquoted.

Updating the tagparser resolves this issue.