### PR TITLE
implemented Writer interface to Encoder.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -61,6 +61,12 @@ func (d *Decoder) Reset(r io.Reader) error {
 	return nil
 }
 
+// Buffered returns a reader of the data remaining in the Decoder's buffer.
+// The reader is valid until the next call to Decode.
+func (d *Decoder) Buffered() io.Reader {
+	return d.r
+}
+
 func (d *Decoder) Decode(v ...interface{}) error {
 	for _, vv := range v {
 		if err := d.decode(vv); err != nil {

--- a/encode.go
+++ b/encode.go
@@ -78,6 +78,11 @@ func (e *Encoder) Encode(v ...interface{}) error {
 	return nil
 }
 
+// Writer returns the Encoder's writer.
+func (e *Encoder) Writer() io.Writer {
+	return e.w
+}
+
 func (e *Encoder) encode(v interface{}) error {
 	switch v := v.(type) {
 	case nil:


### PR DESCRIPTION
Current encoder can't just write 16 bytes, so we have to use old marshaler/unmarshaler to register custom type like UUID.

**Example:**
If we take `google/uuid` (`uuid.UUID` type do not  implement any of msgpack interfaces). We have to call RegisterExt this type. And we receive error, like "invalid msgpack", because of we have to write exactly `16 bytes`, but `msgpack.Encoder.EncodeBytes()` will write `2 bytes (len) + 16 bytes (data)`

If we have a way just write to Encoder what we want, we can just register customEncoder/customDecoder in Register method