### PR TITLE
Use MapRange for map iteration

### DIFF
--- a/encode_map.go
+++ b/encode_map.go
@@ -17,11 +17,12 @@ func encodeMapValue(e *Encoder, v reflect.Value) error {
 		return err
 	}
 
-	for _, key := range v.MapKeys() {
-		if err := e.EncodeValue(key); err != nil {
+	iter := v.MapRange()
+	for iter.Next() {
+		if err := e.EncodeValue(iter.Key()); err != nil {
 			return err
 		}
-		if err := e.EncodeValue(v.MapIndex(key)); err != nil {
+		if err := e.EncodeValue(iter.Value()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This change reduces memory usage and removes unnecessary map iteration for getting all keys in the map.