### PR TITLE
Allow `nil` value to be decoded as bool false

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -341,6 +341,9 @@ func (d *Decoder) DecodeBool() (bool, error) {
 }
 
 func (d *Decoder) bool(c byte) (bool, error) {
+	if c == msgpcode.Nil {
+		return false, nil
+	}
 	if c == msgpcode.False {
 		return false, nil
 	}


### PR DESCRIPTION
A message from another language that allows boolean values to be null/nil/undefined fails to be parsed otherwise with `invalid code=c0 decoding bool`. This would require a type change to `*bool` in Go which is often inconvenient.

Note that this is also inconsistent with for example how `nil` values are unmarshalled into `int` just fine as `0`.