### PR TITLE
Allow overwriting time.Time parsing to another extID

### DIFF
--- a/time.go
+++ b/time.go
@@ -103,7 +103,8 @@ func (d *Decoder) DecodeTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	if extID != timeExtID {
+	// NodeJS seems to use extID 13.
+	if extID != timeExtID && extID != 13 {
 		return time.Time{}, fmt.Errorf("msgpack: invalid time ext id=%d", extID)
 	}
 


### PR DESCRIPTION
Times created in NodeJS with `new Date(...)` are marshalled as extID 13, not -1 as they probably should be.

In order to read them into Go's `time.Time` we would like to use `RegisterExtDecoder(13, time.Time{}, timeDecoder)`. Unmarshalling then fails with `msgpack: invalid time ext id=13`.

Removing the check for `extID == -1` would allow external overwrites to another extID if needed.