### PR TITLE
Allow structure to array encoding using tag for array ordering

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -279,49 +279,33 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 
 	n, err := d.mapLen(c)
 	if err == nil {
-		return d.decodeStruct(v, n)
+		return d.decodeStructValueAsMap(v, n)
 	}
 
 	var err2 error
 	n, err2 = d.arrayLen(c)
-	if err2 != nil {
-		return err
+	if err2 == nil {
+		return d.decodeStructValueAsArray(v, n)
 	}
 
-	if n <= 0 {
-		v.Set(reflect.Zero(v.Type()))
-		return nil
-	}
-
-	fields := structs.Fields(v.Type(), d.structTag)
-	if n != len(fields.List) {
-		return errArrayStruct
-	}
-
-	for _, f := range fields.List {
-		if err := f.DecodeValue(d, v); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return err
 }
 
-func (d *Decoder) decodeStruct(v reflect.Value, n int) error {
+func (d *Decoder) decodeStructValueAsMap(v reflect.Value, n int) error {
 	if n == -1 {
 		v.Set(reflect.Zero(v.Type()))
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag)
+	structFields := structs.Fields(v.Type(), d.structTag)
 	for i := 0; i < n; i++ {
 		name, err := d.decodeStringTemp()
 		if err != nil {
 			return err
 		}
 
-		if f := fields.Map[name]; f != nil {
-			if err := f.DecodeValue(d, v); err != nil {
+		if f := structFields.Map[name]; f != nil {
+			if err := decodeStructFieldValue(d, v, f); err != nil {
 				return err
 			}
 			continue
@@ -336,4 +320,37 @@ func (d *Decoder) decodeStruct(v reflect.Value, n int) error {
 	}
 
 	return nil
+}
+
+func (d *Decoder) decodeStructValueAsArray(v reflect.Value, n int) error {
+	if n <= 0 {
+		v.Set(reflect.Zero(v.Type()))
+		return nil
+	}
+
+	structFields := structs.Fields(v.Type(), d.structTag)
+	fields, err := structFields.OrderArray(d.flags&orderedArrayEncodedStructsFlag != 0)
+	if err != nil {
+		return err
+	}
+	fieldsLen := len(fields)
+
+	if n != fieldsLen && !(structFields.AsOrderedArray || d.flags&orderedArrayEncodedStructsFlag != 0) {
+		return errArrayStruct
+	}
+
+	for i := 0; i < fieldsLen && i < n; i++ {
+		if err := decodeStructFieldValue(d, v, fields[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodeStructFieldValue(d *Decoder, v reflect.Value, f *field) error {
+	if f == nil {
+		return d.Skip()
+	}
+	return f.DecodeValue(d, v)
 }

--- a/encode.go
+++ b/encode.go
@@ -13,6 +13,7 @@ import (
 const (
 	sortMapKeysFlag uint32 = 1 << iota
 	arrayEncodedStructsFlag
+	orderedArrayEncodedStructsFlag
 	useCompactIntsFlag
 	useCompactFloatsFlag
 	useInternedStringsFlag
@@ -163,6 +164,17 @@ func (e *Encoder) UseArrayEncodedStructs(on bool) {
 		e.flags |= arrayEncodedStructsFlag
 	} else {
 		e.flags &= ^arrayEncodedStructsFlag
+	}
+}
+
+// UseOrderedArrayEncodedStructs causes the Encoder to encode Go structs as msgpack arrays.
+// Encoder uses tags to set order of array elements.
+// Encoder sets array element as null if there is no element for that index.
+func (e *Encoder) UseOrderedArrayEncodedStructs(on bool) {
+	if on {
+		e.flags |= orderedArrayEncodedStructsFlag
+	} else {
+		e.flags &= ^orderedArrayEncodedStructsFlag
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -144,8 +144,9 @@ func ExampleEncoder_UseArrayEncodedStructs() {
 func ExampleMarshal_asArray() {
 	type Item struct {
 		_msgpack struct{} `msgpack:",as_array"`
-		Foo      string
-		Bar      string
+
+		Foo string
+		Bar string
 	}
 
 	var buf bytes.Buffer
@@ -162,6 +163,56 @@ func ExampleMarshal_asArray() {
 	}
 	fmt.Println(v)
 	// Output: [foo bar]
+}
+
+func ExampleEncoder_UseOrderedArrayEncodedStructs() {
+	type Item struct {
+		Foo string `msgpack:"0"`
+		// Bar string `msgpack:"1"`
+		Baz string `msgpack:"2"`
+	}
+
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseOrderedArrayEncodedStructs(true)
+
+	err := enc.Encode(&Item{Foo: "foo", Baz: "baz"})
+	if err != nil {
+		panic(err)
+	}
+
+	dec := msgpack.NewDecoder(&buf)
+	v, err := dec.DecodeInterface()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(v)
+	// Output: [foo <nil> baz]
+}
+
+func ExampleMarshal_asOrderedArray() {
+	type Item struct {
+		_msgpack struct{} `msgpack:",as_ordered_array"`
+
+		Foo string `msgpack:"0"`
+		// Bar string `msgpack:"1"`
+		Baz string `msgpack:"2"`
+	}
+
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	err := enc.Encode(&Item{Foo: "foo", Baz: "baz"})
+	if err != nil {
+		panic(err)
+	}
+
+	dec := msgpack.NewDecoder(&buf)
+	v, err := dec.DecodeInterface()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(v)
+	// Output: [foo <nil> baz]
 }
 
 func ExampleMarshal_omitEmpty() {


### PR DESCRIPTION
Allow structure to array encoding using tag for array ordering.

For example:
```
type Item struct {
    _msgpack struct{} `msgpack:",as_ordered_array"`

    Foo string `msgpack:"0"`
    Bar string `msgpack:"2"`
}{
    Foo: "foo",
    Bar: "bar",
}
```
will be converted to:
```
[foo null bar]
```

Such functionality has more performance than struct -> map encoding.

Compared to usual ```as_array``` functionality, ```as_array_ordered``` supports backward compatibility - if one part removes field or adds additional field, another will be still able to decode the structure (given that existing msgpack tag doesn't change and new tag is always bigger than all previous).

This implementation is compatible to MessagePack C# keys:
https://github.com/neuecc/MessagePack-CSharp#object-serialization