### PR TITLE
small optimizations.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	bytesAllocLimit = 1e6 // 1mb
-	sliceAllocLimit = 1e4
-	maxMapSize      = 1e6
+	bytesAllocLimit = 1 << 20 // 1mb
+	sliceAllocLimit = 1e6     // 1m elements
+	maxMapSize      = 1e6     // 1m elements
 )
 
 const (
@@ -55,7 +55,7 @@ func PutDecoder(dec *Decoder) {
 // in the value pointed to by v.
 func Unmarshal(data []byte, v interface{}) error {
 	dec := GetDecoder()
-
+	dec.UsePreallocateValues(true)
 	dec.Reset(bytes.NewReader(data))
 	err := dec.Decode(v)
 

--- a/decode.go
+++ b/decode.go
@@ -116,6 +116,9 @@ func (d *Decoder) ResetReader(r io.Reader) {
 	if br, ok := r.(bufReader); ok {
 		d.r = br
 		d.s = br
+	} else if r == nil {
+		d.r = nil
+		d.s = nil
 	} else {
 		br := bufio.NewReader(r)
 		d.r = br

--- a/decode.go
+++ b/decode.go
@@ -100,7 +100,6 @@ func (d *Decoder) ResetDict(r io.Reader, dict []string) {
 	d.ResetReader(r)
 	d.flags = 0
 	d.structTag = ""
-	d.mapDecoder = nil
 	d.dict = dict
 }
 
@@ -113,6 +112,9 @@ func (d *Decoder) WithDict(dict []string, fn func(*Decoder) error) error {
 }
 
 func (d *Decoder) ResetReader(r io.Reader) {
+	d.mapDecoder = nil
+	d.dict = nil
+
 	if br, ok := r.(bufReader); ok {
 		d.r = br
 		d.s = br

--- a/decode.go
+++ b/decode.go
@@ -68,6 +68,7 @@ type Decoder struct {
 	flags      uint32
 	structTag  string
 	mapDecoder func(*Decoder) (interface{}, error)
+	typeGen    map[reflect.Type]*ptrGen
 }
 
 // NewDecoder returns a new decoder that reads from r.

--- a/decode.go
+++ b/decode.go
@@ -613,12 +613,7 @@ func readN(r io.Reader, b []byte, n int) ([]byte, error) {
 		if n == 0 {
 			return make([]byte, 0), nil
 		}
-		switch {
-		case n < 64:
-			b = make([]byte, 0, 64)
-		default:
-			b = make([]byte, 0, n)
-		}
+		b = make([]byte, 0, n)
 	}
 
 	if n > cap(b) {

--- a/decode.go
+++ b/decode.go
@@ -18,12 +18,6 @@ const (
 	disallowUnknownFieldsFlag
 )
 
-const (
-	bytesAllocLimit = 1e6 // 1mb
-	sliceAllocLimit = 1e4
-	maxMapSize      = 1e6
-)
-
 type bufReader interface {
 	io.Reader
 	io.ByteScanner
@@ -622,37 +616,19 @@ func readN(r io.Reader, b []byte, n int) ([]byte, error) {
 		switch {
 		case n < 64:
 			b = make([]byte, 0, 64)
-		case n <= bytesAllocLimit:
-			b = make([]byte, 0, n)
 		default:
-			b = make([]byte, 0, bytesAllocLimit)
+			b = make([]byte, 0, n)
 		}
 	}
 
-	if n <= cap(b) {
+	if n > cap(b) {
+		b = append(b, make([]byte, n-len(b))...)
+	} else if n <= cap(b) {
 		b = b[:n]
-		_, err := io.ReadFull(r, b)
-		return b, err
-	}
-	b = b[:cap(b)]
-
-	var pos int
-	for {
-		alloc := min(n-len(b), bytesAllocLimit)
-		b = append(b, make([]byte, alloc)...)
-
-		_, err := io.ReadFull(r, b[pos:])
-		if err != nil {
-			return b, err
-		}
-
-		if len(b) == n {
-			break
-		}
-		pos = len(b)
 	}
 
-	return b, nil
+	_, err := io.ReadFull(r, b)
+	return b, err
 }
 
 func min(a, b int) int { //nolint:unparam

--- a/decode.go
+++ b/decode.go
@@ -23,7 +23,7 @@ const (
 	looseInterfaceDecodingFlag uint32 = 1 << iota
 	disallowUnknownFieldsFlag
 	usePreallocateValues
-	disablePartialAllocFlag
+	disableAllocLimitFlag
 )
 
 type bufReader interface {
@@ -172,12 +172,12 @@ func (d *Decoder) UsePreallocateValues(on bool) {
 	}
 }
 
-// DisablePartialAlloc enables fully allocating slices/maps when the size is known
-func (d *Decoder) DisablePartialAlloc(on bool) {
+// DisableAllocLimit enables fully allocating slices/maps when the size is known
+func (d *Decoder) DisableAllocLimit(on bool) {
 	if on {
-		d.flags |= disablePartialAllocFlag
+		d.flags |= disableAllocLimitFlag
 	} else {
-		d.flags &= ^disablePartialAllocFlag
+		d.flags &= ^disableAllocLimitFlag
 	}
 }
 

--- a/decode.go
+++ b/decode.go
@@ -97,7 +97,7 @@ func (d *Decoder) Reset(r io.Reader) {
 
 // ResetDict is like Reset, but also resets the dict.
 func (d *Decoder) ResetDict(r io.Reader, dict []string) {
-	d.resetReader(r)
+	d.ResetReader(r)
 	d.flags = 0
 	d.structTag = ""
 	d.mapDecoder = nil
@@ -112,7 +112,7 @@ func (d *Decoder) WithDict(dict []string, fn func(*Decoder) error) error {
 	return err
 }
 
-func (d *Decoder) resetReader(r io.Reader) {
+func (d *Decoder) ResetReader(r io.Reader) {
 	if br, ok := r.(bufReader); ok {
 		d.r = br
 		d.s = br
@@ -623,7 +623,7 @@ func (d *Decoder) readFull(b []byte) error {
 
 func (d *Decoder) readN(n int) ([]byte, error) {
 	var err error
-	if d.flags&disablePartialAllocFlag != 0 {
+	if d.flags&disableAllocLimitFlag != 0 {
 		d.buf, err = readN(d.r, d.buf, n)
 	} else {
 		d.buf, err = readNGrow(d.r, d.buf, n)

--- a/decode.go
+++ b/decode.go
@@ -66,16 +66,14 @@ func Unmarshal(data []byte, v interface{}) error {
 
 // A Decoder reads and decodes MessagePack values from an input stream.
 type Decoder struct {
-	r   io.Reader
-	s   io.ByteScanner
-	buf []byte
-
-	rec []byte // accumulates read data if not nil
-
+	r          io.Reader
+	s          io.ByteScanner
+	mapDecoder func(*Decoder) (interface{}, error)
+	structTag  string
+	buf        []byte
+	rec        []byte
 	dict       []string
 	flags      uint32
-	structTag  string
-	mapDecoder func(*Decoder) (interface{}, error)
 }
 
 // NewDecoder returns a new decoder that reads from r.

--- a/decode_map.go
+++ b/decode_map.go
@@ -33,7 +33,7 @@ func decodeMapValue(d *Decoder, v reflect.Value) error {
 	}
 
 	if v.IsNil() {
-		v.Set(reflect.MakeMap(typ))
+		v.Set(reflect.MakeMapWithSize(typ, n))
 	}
 	if n == 0 {
 		return nil
@@ -222,7 +222,7 @@ func (d *Decoder) DecodeTypedMap() (interface{}, error) {
 	}
 
 	mapType := reflect.MapOf(keyType, valueType)
-	mapValue := reflect.MakeMap(mapType)
+	mapValue := reflect.MakeMapWithSize(mapType, n)
 	mapValue.SetMapIndex(reflect.ValueOf(key), reflect.ValueOf(value))
 
 	n--
@@ -234,17 +234,18 @@ func (d *Decoder) DecodeTypedMap() (interface{}, error) {
 }
 
 func (d *Decoder) decodeTypedMapValue(v reflect.Value, n int) error {
-	typ := v.Type()
-	keyType := typ.Key()
-	valueType := typ.Elem()
-
+	var (
+		typ       = v.Type()
+		keyType   = typ.Key()
+		valueType = typ.Elem()
+	)
 	for i := 0; i < n; i++ {
-		mk := reflect.New(keyType).Elem()
+		mk := d.newValue(keyType).Elem()
 		if err := d.DecodeValue(mk); err != nil {
 			return err
 		}
 
-		mv := reflect.New(valueType).Elem()
+		mv := d.newValue(valueType).Elem()
 		if err := d.DecodeValue(mv); err != nil {
 			return err
 		}

--- a/decode_map.go
+++ b/decode_map.go
@@ -104,7 +104,7 @@ func (d *Decoder) decodeMapStringStringPtr(ptr *map[string]string) error {
 
 	m := *ptr
 	if m == nil {
-		*ptr = make(map[string]string, min(size, maxMapSize))
+		*ptr = make(map[string]string, size)
 		m = *ptr
 	}
 
@@ -147,7 +147,7 @@ func (d *Decoder) DecodeMap() (map[string]interface{}, error) {
 		return nil, nil
 	}
 
-	m := make(map[string]interface{}, min(n, maxMapSize))
+	m := make(map[string]interface{}, n)
 
 	for i := 0; i < n; i++ {
 		mk, err := d.DecodeString()
@@ -174,7 +174,7 @@ func (d *Decoder) DecodeUntypedMap() (map[interface{}]interface{}, error) {
 		return nil, nil
 	}
 
-	m := make(map[interface{}]interface{}, min(n, maxMapSize))
+	m := make(map[interface{}]interface{}, n)
 
 	for i := 0; i < n; i++ {
 		mk, err := d.decodeInterfaceCond()

--- a/decode_map.go
+++ b/decode_map.go
@@ -34,7 +34,7 @@ func decodeMapValue(d *Decoder, v reflect.Value) error {
 
 	if v.IsNil() {
 		size := n
-		if d.flags&disablePartialAllocFlag == 0 {
+		if d.flags&disableAllocLimitFlag == 0 {
 			size = min(size, maxMapSize)
 		}
 		v.Set(reflect.MakeMapWithSize(typ, size))
@@ -108,7 +108,7 @@ func (d *Decoder) decodeMapStringStringPtr(ptr *map[string]string) error {
 
 	m := *ptr
 	if m == nil {
-		if d.flags&disablePartialAllocFlag == 0 {
+		if d.flags&disableAllocLimitFlag == 0 {
 			size = min(size, maxMapSize)
 		}
 		*ptr = make(map[string]string, size)
@@ -231,7 +231,7 @@ func (d *Decoder) DecodeTypedMap() (interface{}, error) {
 	mapType := reflect.MapOf(keyType, valueType)
 
 	size := n
-	if d.flags&disablePartialAllocFlag == 0 {
+	if d.flags&disableAllocLimitFlag == 0 {
 		size = min(size, maxMapSize)
 	}
 

--- a/decode_map.go
+++ b/decode_map.go
@@ -33,11 +33,11 @@ func decodeMapValue(d *Decoder, v reflect.Value) error {
 	}
 
 	if v.IsNil() {
-		size := n
+		ln := n
 		if d.flags&disableAllocLimitFlag == 0 {
-			size = min(size, maxMapSize)
+			ln = min(ln, maxMapSize)
 		}
-		v.Set(reflect.MakeMapWithSize(typ, size))
+		v.Set(reflect.MakeMapWithSize(typ, ln))
 	}
 	if n == 0 {
 		return nil
@@ -108,10 +108,11 @@ func (d *Decoder) decodeMapStringStringPtr(ptr *map[string]string) error {
 
 	m := *ptr
 	if m == nil {
+		ln := size
 		if d.flags&disableAllocLimitFlag == 0 {
-			size = min(size, maxMapSize)
+			ln = min(size, maxMapSize)
 		}
-		*ptr = make(map[string]string, size)
+		*ptr = make(map[string]string, ln)
 		m = *ptr
 	}
 
@@ -230,12 +231,12 @@ func (d *Decoder) DecodeTypedMap() (interface{}, error) {
 
 	mapType := reflect.MapOf(keyType, valueType)
 
-	size := n
+	ln := n
 	if d.flags&disableAllocLimitFlag == 0 {
-		size = min(size, maxMapSize)
+		ln = min(ln, maxMapSize)
 	}
 
-	mapValue := reflect.MakeMapWithSize(mapType, size)
+	mapValue := reflect.MakeMapWithSize(mapType, ln)
 	mapValue.SetMapIndex(reflect.ValueOf(key), reflect.ValueOf(value))
 
 	n--

--- a/decode_query.go
+++ b/decode_query.go
@@ -11,9 +11,8 @@ import (
 type queryResult struct {
 	query       string
 	key         string
+	values      []interface{}
 	hasAsterisk bool
-
-	values []interface{}
 }
 
 func (q *queryResult) nextKey() {

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -101,10 +101,11 @@ func decodeSliceValue(d *Decoder, v reflect.Value) error {
 		v.Set(v.Slice(0, v.Cap()))
 	}
 
+	if n > v.Len() {
+		v.Set(growSliceValue(v, n))
+	}
+
 	for i := 0; i < n; i++ {
-		if i >= v.Len() {
-			v.Set(growSliceValue(v, n))
-		}
 		elem := v.Index(i)
 		if err := d.DecodeValue(elem); err != nil {
 			return err

--- a/decode_typgen.go
+++ b/decode_typgen.go
@@ -1,0 +1,42 @@
+package msgpack
+
+import (
+	"reflect"
+)
+
+func (d *Decoder) newValue(t reflect.Type) reflect.Value {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	gen := d.typeGen[t]
+
+	if gen == nil {
+		if d.typeGen == nil {
+			d.typeGen = map[reflect.Type]*ptrGen{}
+		}
+		gen = &ptrGen{typ: t, cap: 4096}
+		d.typeGen[t] = gen
+	}
+
+	return gen.next()
+}
+
+type ptrGen struct {
+	raw reflect.Value
+	typ reflect.Type
+	idx int
+	cap int
+}
+
+func (p *ptrGen) next() (v reflect.Value) {
+	if p.idx == p.cap || !p.raw.IsValid() {
+		p.raw = reflect.MakeSlice(reflect.SliceOf(p.typ), p.cap, p.cap)
+		p.idx = 0
+	}
+
+	v = p.raw.Index(p.idx).Addr()
+	p.idx++
+
+	return
+}

--- a/decode_typgen.go
+++ b/decode_typgen.go
@@ -57,8 +57,8 @@ func (d *Decoder) newValue(t reflect.Type) reflect.Value {
 
 type ptrGen struct {
 	sync.Mutex
-	raw reflect.Value
 	typ reflect.Type
+	raw reflect.Value
 	idx int
 	cap int
 }

--- a/decode_value.go
+++ b/decode_value.go
@@ -127,12 +127,12 @@ func ptrValueDecoder(typ reflect.Type) decoderFunc {
 	return func(d *Decoder, v reflect.Value) error {
 		if d.hasNilCode() {
 			if !v.IsNil() {
-				v.Set(reflect.Zero(v.Type()))
+				v.Set(d.newValue(typ))
 			}
 			return d.DecodeNil()
 		}
 		if v.IsNil() {
-			v.Set(reflect.New(v.Type().Elem()))
+			v.Set(d.newValue(typ))
 		}
 		return decoder(d, v.Elem())
 	}
@@ -154,7 +154,7 @@ func nilAwareDecoder(typ reflect.Type, fn decoderFunc) decoderFunc {
 				return d.decodeNilValue(v)
 			}
 			if v.IsNil() {
-				v.Set(reflect.New(v.Type().Elem()))
+				v.Set(d.newValue(typ))
 			}
 			return fn(d, v)
 		}

--- a/decode_value.go
+++ b/decode_value.go
@@ -132,7 +132,7 @@ func ptrValueDecoder(typ reflect.Type) decoderFunc {
 			return d.DecodeNil()
 		}
 		if v.IsNil() {
-			v.Set(d.newValue(typ))
+			v.Set(d.newValue(typ.Elem()))
 		}
 		return decoder(d, v.Elem())
 	}
@@ -154,7 +154,7 @@ func nilAwareDecoder(typ reflect.Type, fn decoderFunc) decoderFunc {
 				return d.decodeNilValue(v)
 			}
 			if v.IsNil() {
-				v.Set(d.newValue(typ))
+				v.Set(d.newValue(typ.Elem()))
 			}
 			return fn(d, v)
 		}

--- a/encode.go
+++ b/encode.go
@@ -75,15 +75,12 @@ func Marshal(v interface{}) ([]byte, error) {
 }
 
 type Encoder struct {
-	w writer
-
-	buf     []byte
-	timeBuf []byte
-
-	dict map[string]int
-
-	flags     uint32
+	w         writer
+	dict      map[string]int
 	structTag string
+	buf       []byte
+	timeBuf   []byte
+	flags     uint32
 }
 
 // NewEncoder returns a new encoder that writes to w.

--- a/encode.go
+++ b/encode.go
@@ -122,6 +122,7 @@ func (e *Encoder) WithDict(dict map[string]int, fn func(*Encoder) error) error {
 }
 
 func (e *Encoder) ResetWriter(w io.Writer) {
+	e.dict = nil
 	if bw, ok := w.(writer); ok {
 		e.w = bw
 	} else if w == nil {

--- a/encode.go
+++ b/encode.go
@@ -124,6 +124,8 @@ func (e *Encoder) WithDict(dict map[string]int, fn func(*Encoder) error) error {
 func (e *Encoder) ResetWriter(w io.Writer) {
 	if bw, ok := w.(writer); ok {
 		e.w = bw
+	} else if w == nil {
+		e.w = nil
 	} else {
 		e.w = newByteWriter(w)
 	}

--- a/encode.go
+++ b/encode.go
@@ -107,7 +107,7 @@ func (e *Encoder) Reset(w io.Writer) {
 
 // ResetDict is like Reset, but also resets the dict.
 func (e *Encoder) ResetDict(w io.Writer, dict map[string]int) {
-	e.resetWriter(w)
+	e.ResetWriter(w)
 	e.flags = 0
 	e.structTag = ""
 	e.dict = dict
@@ -121,7 +121,7 @@ func (e *Encoder) WithDict(dict map[string]int, fn func(*Encoder) error) error {
 	return err
 }
 
-func (e *Encoder) resetWriter(w io.Writer) {
+func (e *Encoder) ResetWriter(w io.Writer) {
 	if bw, ok := w.(writer); ok {
 		e.w = bw
 	} else {

--- a/encode_value.go
+++ b/encode_value.go
@@ -198,6 +198,13 @@ func nilable(kind reflect.Kind) bool {
 	return false
 }
 
+func nilableType(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return nilable(t.Kind())
+}
+
 //------------------------------------------------------------------------------
 
 func marshalBinaryValueAddr(e *Encoder, v reflect.Value) error {

--- a/ext.go
+++ b/ext.go
@@ -256,7 +256,7 @@ func (d *Decoder) decodeInterfaceExt(c byte) (interface{}, error) {
 
 	v := reflect.New(info.Type).Elem()
 	if nilable(v.Kind()) && v.IsNil() {
-		v.Set(d.newValue(v.Type().Elem()))
+		v.Set(d.newValue(info.Type.Elem()))
 	}
 
 	if err := info.Decoder(d, v, extLen); err != nil {

--- a/ext.go
+++ b/ext.go
@@ -256,7 +256,7 @@ func (d *Decoder) decodeInterfaceExt(c byte) (interface{}, error) {
 
 	v := reflect.New(info.Type).Elem()
 	if nilable(v.Kind()) && v.IsNil() {
-		v.Set(reflect.New(info.Type.Elem()))
+		v.Set(d.newValue(v.Type().Elem()))
 	}
 
 	if err := info.Decoder(d, v, extLen); err != nil {

--- a/ext.go
+++ b/ext.go
@@ -254,7 +254,7 @@ func (d *Decoder) decodeInterfaceExt(c byte) (interface{}, error) {
 		return nil, fmt.Errorf("msgpack: unknown ext id=%d", extID)
 	}
 
-	v := reflect.New(info.Type).Elem()
+	v := d.newValue(info.Type).Elem()
 	if nilable(v.Kind()) && v.IsNil() {
 		v.Set(d.newValue(info.Type.Elem()))
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
 module github.com/vmihailenco/msgpack/v5
 
-go 1.11
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.6.1
 	github.com/vmihailenco/tagparser/v2 v2.0.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/msgpack.go
+++ b/msgpack.go
@@ -43,8 +43,8 @@ func (m *RawMessage) DecodeMsgpack(dec *Decoder) error {
 //------------------------------------------------------------------------------
 
 type unexpectedCodeError struct {
-	code byte
 	hint string
+	code byte
 }
 
 func (err unexpectedCodeError) Error() string {

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -49,7 +49,6 @@ func (t *MsgpackTest) TestTime() {
 	t.Nil(t.dec.Decode(&out))
 	t.True(out.Equal(zero))
 	t.True(out.IsZero())
-
 }
 
 func (t *MsgpackTest) TestLargeBytes() {
@@ -460,14 +459,15 @@ func ExampleMarshal_ignore_simple_zero_structs_when_tagged_with_omitempty() {
 	// msgpack_test.T{I:msgpack_test.NullInt{Valid:true, Int:42}, J:msgpack_test.NullInt{Valid:true, Int:0}, S:msgpack_test.Secretive{Visible:false, hidden:false}}
 }
 
-type Value interface{}
-type Wrapper struct {
-	Value Value `msgpack:"v,omitempty"`
-}
+type (
+	Value   interface{}
+	Wrapper struct {
+		Value Value `msgpack:"v,omitempty"`
+	}
+)
 
 func TestEncodeWrappedValue(t *testing.T) {
-	var v Value
-	v = (*time.Time)(nil)
+	v := (*time.Time)(nil)
 	c := &Wrapper{
 		Value: v,
 	}

--- a/types.go
+++ b/types.go
@@ -66,8 +66,8 @@ type structCache struct {
 }
 
 type structCacheKey struct {
-	tag string
 	typ reflect.Type
+	tag string
 }
 
 func newStructCache() *structCache {
@@ -90,11 +90,11 @@ func (m *structCache) Fields(typ reflect.Type, tag string) *fields {
 //------------------------------------------------------------------------------
 
 type field struct {
+	encoder   encoderFunc
+	decoder   decoderFunc
 	name      string
 	index     []int
 	omitEmpty bool
-	encoder   encoderFunc
-	decoder   decoderFunc
 }
 
 func (f *field) Omit(strct reflect.Value, forced bool) bool {

--- a/types.go
+++ b/types.go
@@ -399,7 +399,7 @@ func indirectNil(v reflect.Value) (reflect.Value, bool) {
 			if elemType.Kind() != reflect.Struct {
 				return v, false
 			}
-			v.Set(reflect.New(elemType))
+			v.Set(getTypeGen(elemType).next())
 		}
 		v = v.Elem()
 	}

--- a/types.go
+++ b/types.go
@@ -399,7 +399,7 @@ func indirectNil(v reflect.Value) (reflect.Value, bool) {
 			if elemType.Kind() != reflect.Struct {
 				return v, false
 			}
-			v.Set(getTypeGen(elemType).next())
+			v.Set(cachedValue(elemType))
 		}
 		v = v.Elem()
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -778,8 +778,7 @@ func TestStringsBin(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, v.(string), test.in)
 
-		var dst interface{}
-		dst = ""
+		var dst interface{} = ""
 		err = msgpack.Unmarshal(b, &dst)
 		require.EqualError(t, err, "msgpack: Decode(non-pointer string)")
 	}
@@ -846,8 +845,7 @@ func TestBin(t *testing.T) {
 			t.Fatalf("%x != %x", v, test.in)
 		}
 
-		var dst interface{}
-		dst = make([]byte, 0)
+		var dst interface{} = make([]byte, 0)
 		err = msgpack.Unmarshal(b, &dst)
 		if err.Error() != "msgpack: Decode(non-pointer []uint8)" {
 			t.Fatal(err)
@@ -910,8 +908,7 @@ func TestUint64(t *testing.T) {
 			t.Fatalf("%d != %d", out2, int64(test.in))
 		}
 
-		var out3 interface{}
-		out3 = uint64(0)
+		var out3 interface{} = uint64(0)
 		err = msgpack.Unmarshal(buf.Bytes(), &out3)
 		if err.Error() != "msgpack: Decode(non-pointer uint64)" {
 			t.Fatal(err)
@@ -998,8 +995,7 @@ func TestInt64(t *testing.T) {
 			t.Fatalf("%d != %d", out2, uint64(test.in))
 		}
 
-		var out3 interface{}
-		out3 = int64(0)
+		var out3 interface{} = int64(0)
 		err = msgpack.Unmarshal(buf.Bytes(), &out3)
 		if err.Error() != "msgpack: Decode(non-pointer int64)" {
 			t.Fatal(err)
@@ -1068,8 +1064,7 @@ func TestFloat32(t *testing.T) {
 			t.Fatalf("%f != %f", v, test.in)
 		}
 
-		var dst interface{}
-		dst = float32(0)
+		var dst interface{} = float32(0)
 		err = msgpack.Unmarshal(b, &dst)
 		if err.Error() != "msgpack: Decode(non-pointer float32)" {
 			t.Fatal(err)
@@ -1134,8 +1129,7 @@ func TestFloat64(t *testing.T) {
 			t.Fatalf("%f != %f", v, test.in)
 		}
 
-		var dst interface{}
-		dst = float64(0)
+		var dst interface{} = float64(0)
 		err = msgpack.Unmarshal(b, &dst)
 		if err.Error() != "msgpack: Decode(non-pointer float64)" {
 			t.Fatal(err)


### PR DESCRIPTION
Hello, here at @AlpineIQ we use msgpack extensively, however as some of our caches grew, we hit some roadblocks with memory for decoding.

I took a crack at the decoder and come up with this PR:

- remove `bytesAllocLimit/sliceAllocLimit/maxMapSize`, always allocate the full size since it's known beforehand.
- allocate types in blocks instead of one at a time.

I know it might look like a micro-optimization but it's extremely significant at the scale we use it for, it's the difference between running OO< on a 5.75TB instance and only using 1.4TB.

Our internal benchmark (Can't provide a test file, but it's about 159mb, the real files are 1-2gb): 
```sh
BenchmarkOrig-32	3	23014189915 ns/op	2270733298 B/op	130404548 allocs/op
BenchmarkFork-32	3	22803649859 ns/op	2213246725 B/op	126130710 allocs/op
```

Benchstat of the all msgpack tests, no real changes:

```sh
# generated with go test -benchmem -bench='Map|Struct' -benchtime=10s 

name                          old time/op    new time/op    delta
MapStringString-32               472ns ± 0%     460ns ± 0%   ~     (p=1.000 n=1+1)
MapStringStringPtr-32            618ns ± 0%     618ns ± 0%   ~     (p=1.000 n=1+1)
MapStringInterfaceMsgpack-32    1.26µs ± 0%    1.14µs ± 0%   ~     (p=1.000 n=1+1)
MapStringInterfaceJSON-32       5.00µs ± 0%    4.61µs ± 0%   ~     (p=1.000 n=1+1)
MapIntInt-32                    1.14µs ± 0%    1.13µs ± 0%   ~     (p=1.000 n=1+1)
StructVmihailencoMsgpack-32     3.57µs ± 0%    2.90µs ± 0%   ~     (p=1.000 n=1+1)
StructMarshal-32                1.92µs ± 0%    1.31µs ± 0%   ~     (p=1.000 n=1+1)
StructUnmarshal-32              1.43µs ± 0%    1.39µs ± 0%   ~     (p=1.000 n=1+1)
StructManual-32                 2.37µs ± 0%    2.04µs ± 0%   ~     (p=1.000 n=1+1)
StructUnmarshalPartially-32     1.01µs ± 0%    0.96µs ± 0%   ~     (p=1.000 n=1+1)

name                          old alloc/op   new alloc/op   delta
MapStringString-32               16.0B ± 0%     16.0B ± 0%   ~     (all equal)
MapStringStringPtr-32            16.0B ± 0%     16.0B ± 0%   ~     (all equal)
MapStringInterfaceMsgpack-32      402B ± 0%      402B ± 0%   ~     (all equal)
MapStringInterfaceJSON-32         920B ± 0%      920B ± 0%   ~     (all equal)
MapIntInt-32                      192B ± 0%      192B ± 0%   ~     (all equal)
StructVmihailencoMsgpack-32     1.83kB ± 0%    1.83kB ± 0%   ~     (p=1.000 n=1+1)
StructMarshal-32                1.74kB ± 0%    1.74kB ± 0%   ~     (p=1.000 n=1+1)
StructUnmarshal-32               96.0B ± 0%     96.0B ± 0%   ~     (all equal)
StructManual-32                 1.49kB ± 0%    1.49kB ± 0%   ~     (p=1.000 n=1+1)
StructUnmarshalPartially-32      64.0B ± 0%     64.0B ± 0%   ~     (all equal)

name                          old allocs/op  new allocs/op  delta
MapStringString-32                4.00 ± 0%      4.00 ± 0%   ~     (all equal)
MapStringStringPtr-32             4.00 ± 0%      4.00 ± 0%   ~     (all equal)
MapStringInterfaceMsgpack-32      12.0 ± 0%      12.0 ± 0%   ~     (all equal)
MapStringInterfaceJSON-32         34.0 ± 0%      34.0 ± 0%   ~     (all equal)
MapIntInt-32                      9.00 ± 0%      5.00 ± 0%   ~     (p=1.000 n=1+1)
StructVmihailencoMsgpack-32       15.0 ± 0%      15.0 ± 0%   ~     (all equal)
StructMarshal-32                  7.00 ± 0%      7.00 ± 0%   ~     (all equal)
StructUnmarshal-32                8.00 ± 0%      8.00 ± 0%   ~     (all equal)
StructManual-32                   17.0 ± 0%      17.0 ± 0%   ~     (all equal)
StructUnmarshalPartially-32       2.00 ± 0%      2.00 ± 0%   ~     (all equal)

```