### PR TITLE
Fix unmarshaling an empty time struct when an interface is supplied to unmarshal function

### DIFF
--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -247,6 +247,33 @@ func TestEmbedding(t *testing.T) {
 	}
 }
 
+func TestEmptyTimeMarshalWithInterface(t *testing.T) {
+	a := time.Time{}
+	b, err := msgpack.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out interface{}
+	err = msgpack.Unmarshal(b, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, _ := out.(time.Time).Zone()
+	if name != "UTC" {
+		t.Fatal("Got wrong timezone")
+	}
+
+	var out2 time.Time
+	err = msgpack.Unmarshal(b, &out2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, _ = out2.Zone()
+	if name != "UTC" {
+		t.Fatal("Got wrong timezone")
+	}
+}
+
 func (t *MsgpackTest) TestSliceNil() {
 	in := [][]*int{nil}
 	var out [][]*int

--- a/time.go
+++ b/time.go
@@ -26,6 +26,11 @@ func timeDecoder(d *Decoder, v reflect.Value, extLen int) error {
 		return err
 	}
 
+	if tm.IsZero() {
+		// Zero time does not have timezone information.
+		tm = tm.UTC()
+	}
+
 	ptr := v.Addr().Interface().(*time.Time)
 	*ptr = tm
 


### PR DESCRIPTION

When a time.Time struct is supplied, the decode function goes in another path, and the UTC timezone is set on the empty time object
Added this now to the path when an interface is supplied
fixes https://github.com/vmihailenco/msgpack/issues/332
