### PR TITLE
add option to enable encode and decode exported fields of struct

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -16,6 +16,7 @@ import (
 const (
 	looseInterfaceDecodingFlag uint32 = 1 << iota
 	disallowUnknownFieldsFlag
+	decodeUnexportedFieldsFlag
 )
 
 const (
@@ -158,6 +159,15 @@ func (d *Decoder) UseInternedStrings(on bool) {
 		d.flags |= useInternedStringsFlag
 	} else {
 		d.flags &= ^useInternedStringsFlag
+	}
+}
+
+// DecodeUnexportedFields enables decode value for unexported struct fields
+func (d *Decoder) DecodeUnexportedFields(on bool) {
+	if on {
+		d.flags |= decodeUnexportedFieldsFlag
+	} else {
+		d.flags &= ^decodeUnexportedFieldsFlag
 	}
 }
 

--- a/decode_map.go
+++ b/decode_map.go
@@ -293,7 +293,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag)
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&decodeUnexportedFieldsFlag != 0)
 	if n != len(fields.List) {
 		return errArrayStruct
 	}
@@ -313,7 +313,7 @@ func (d *Decoder) decodeStruct(v reflect.Value, n int) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag)
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&decodeUnexportedFieldsFlag != 0)
 	for i := 0; i < n; i++ {
 		name, err := d.decodeStringTemp()
 		if err != nil {

--- a/encode.go
+++ b/encode.go
@@ -17,6 +17,7 @@ const (
 	useCompactFloatsFlag
 	useInternedStringsFlag
 	omitEmptyFlag
+	encodeUnexportedFieldsFlag
 )
 
 type writer interface {
@@ -154,6 +155,15 @@ func (e *Encoder) SetOmitEmpty(on bool) {
 		e.flags |= omitEmptyFlag
 	} else {
 		e.flags &= ^omitEmptyFlag
+	}
+}
+
+// SetEncodeUnexportedFields causes the encoder to encode the unexported fields of struct.
+func (e *Encoder) SetEncodeUnexportedFields(on bool) {
+	if on {
+		e.flags |= encodeUnexportedFieldsFlag
+	} else {
+		e.flags &= ^encodeUnexportedFieldsFlag
 	}
 }
 

--- a/encode_map.go
+++ b/encode_map.go
@@ -144,7 +144,7 @@ func (e *Encoder) EncodeMapLen(l int) error {
 }
 
 func encodeStructValue(e *Encoder, strct reflect.Value) error {
-	structFields := structs.Fields(strct.Type(), e.structTag)
+	structFields := structs.Fields(strct.Type(), e.structTag, e.flags&encodeUnexportedFieldsFlag != 0)
 	if e.flags&arrayEncodedStructsFlag != 0 || structFields.AsArray {
 		return encodeStructValueAsArray(e, strct, structFields.List)
 	}


### PR DESCRIPTION
as have discussed in [issues/270](https://github.com/vmihailenco/msgpack/issues/270), it's desirable to have an option to enable encode and decode exported fields of a struct. Through there's mechanism to customize encoding and decoder for specific struct，it's not suitable for implementing a genera searializer, in which case the struct is not known in compilation time.