### PR TITLE
make error array struct public, change marshal/unmarshal algorithm

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vmihailenco/msgpack/v5/msgpcode"
 )
 
-var errArrayStruct = errors.New("msgpack: number of fields in array-encoded struct has changed")
+var ErrArrayStruct = errors.New("msgpack: number of fields in array-encoded struct has changed")
 
 var (
 	mapStringStringPtrType = reflect.TypeOf((*map[string]string)(nil))
@@ -295,7 +295,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 
 	fields := structs.Fields(v.Type(), d.structTag)
 	if n != len(fields.List) {
-		return errArrayStruct
+		return ErrArrayStruct
 	}
 
 	for _, f := range fields.List {


### PR DESCRIPTION
Make the ErrArrayStruct public for opportunity use errors.Is in project to separate the error from the others. It's useful in big projects with frequent releases which contain a lot of changes