### PR TITLE
update project version to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [v5]
+    branches: [v6]
   pull_request:
-    branches: [v5]
+    branches: [v6]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MessagePack encoding for Golang
 
 [![Build Status](https://travis-ci.org/vmihailenco/msgpack.svg)](https://travis-ci.org/vmihailenco/msgpack)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/vmihailenco/msgpack/v5)](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/vmihailenco/msgpack/v6)](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6)
 [![Documentation](https://img.shields.io/badge/msgpack-documentation-informational)](https://msgpack.uptrace.dev/)
 [![Chat](https://discordapp.com/api/guilds/752070105847955518/widget.png)](https://discord.gg/rWtp5Aj)
 
@@ -14,35 +14,35 @@
 
 - [Documentation](https://msgpack.uptrace.dev)
 - [Chat](https://discord.gg/rWtp5Aj)
-- [Reference](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5)
-- [Examples](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#pkg-examples)
+- [Reference](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6)
+- [Examples](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#pkg-examples)
 
 ## Features
 
 - Primitives, arrays, maps, structs, time.Time and interface{}.
 - Appengine \*datastore.Key and datastore.Cursor.
 - [CustomEncoder]/[CustomDecoder] interfaces for custom encoding.
-- [Extensions](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#example-RegisterExt) to encode
+- [Extensions](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#example-RegisterExt) to encode
   type information.
 - Renaming fields via `msgpack:"my_field_name"` and alias via `msgpack:"alias:another_name"`.
 - Omitting individual empty fields via `msgpack:",omitempty"` tag or all
-  [empty fields in a struct](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#example-Marshal-OmitEmpty).
-- [Map keys sorting](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#Encoder.SetSortMapKeys).
+  [empty fields in a struct](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#example-Marshal-OmitEmpty).
+- [Map keys sorting](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#Encoder.SetSortMapKeys).
 - Encoding/decoding all
-  [structs as arrays](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#Encoder.UseArrayEncodedStructs)
+  [structs as arrays](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#Encoder.UseArrayEncodedStructs)
   or
-  [individual structs](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#example-Marshal-AsArray).
+  [individual structs](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#example-Marshal-AsArray).
 - [Encoder.SetCustomStructTag] with [Decoder.SetCustomStructTag] can turn msgpack into drop-in
   replacement for any tag.
 - Simple but very fast and efficient
-  [queries](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#example-Decoder.Query).
+  [queries](https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#example-Decoder.Query).
 
-[customencoder]: https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#CustomEncoder
-[customdecoder]: https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#CustomDecoder
+[customencoder]: https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#CustomEncoder
+[customdecoder]: https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#CustomDecoder
 [encoder.setcustomstructtag]:
-  https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#Encoder.SetCustomStructTag
+  https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#Encoder.SetCustomStructTag
 [decoder.setcustomstructtag]:
-  https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#Decoder.SetCustomStructTag
+  https://pkg.go.dev/github.com/vmihailenco/msgpack/v6#Decoder.SetCustomStructTag
 
 ## Installation
 
@@ -56,13 +56,13 @@ go mod init github.com/my/repo
 And then install msgpack/v5 (note _v5_ in the import; omitting it is a popular mistake):
 
 ```shell
-go get github.com/vmihailenco/msgpack/v5
+go get github.com/vmihailenco/msgpack/v6
 ```
 
 ## Quickstart
 
 ```go
-import "github.com/vmihailenco/msgpack/v5"
+import "github.com/vmihailenco/msgpack/v6"
 
 func ExampleMarshal() {
     type Item struct {

--- a/bench_test.go
+++ b/bench_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v6"
 )
 
 func BenchmarkDiscard(b *testing.B) {

--- a/decode.go
+++ b/decode.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 const (

--- a/decode_map.go
+++ b/decode_map.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 var ErrArrayStruct = errors.New("msgpack: number of fields in array-encoded struct has changed")

--- a/decode_map.go
+++ b/decode_map.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vmihailenco/msgpack/v5/msgpcode"
 )
 
-var errArrayStruct = errors.New("msgpack: number of fields in array-encoded struct has changed")
+var ErrArrayStruct = errors.New("msgpack: number of fields in array-encoded struct has changed")
 
 var (
 	mapStringStringPtrType = reflect.TypeOf((*map[string]string)(nil))
@@ -295,7 +295,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 
 	fields := structs.Fields(v.Type(), d.structTag)
 	if n != len(fields.List) {
-		return errArrayStruct
+		return ErrArrayStruct
 	}
 
 	for _, f := range fields.List {

--- a/decode_number.go
+++ b/decode_number.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 func (d *Decoder) skipN(n int) error {

--- a/decode_query.go
+++ b/decode_query.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 type queryResult struct {

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 var sliceStringPtrType = reflect.TypeOf((*[]string)(nil))

--- a/decode_string.go
+++ b/decode_string.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 func (d *Decoder) bytesLen(c byte) (int, error) {

--- a/encode.go
+++ b/encode.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 const (

--- a/encode_map.go
+++ b/encode_map.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 func encodeMapValue(e *Encoder, v reflect.Value) error {

--- a/encode_number.go
+++ b/encode_number.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 // EncodeUint8 encodes an uint8 in 2 bytes preserving type of the number.

--- a/encode_slice.go
+++ b/encode_slice.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 var stringSliceType = reflect.TypeOf(([]string)(nil))

--- a/example_CustomEncoder_test.go
+++ b/example_CustomEncoder_test.go
@@ -3,7 +3,7 @@ package msgpack_test
 import (
 	"fmt"
 
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v6"
 )
 
 type customStruct struct {

--- a/example_registerExt_test.go
+++ b/example_registerExt_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v6"
 )
 
 // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v6"
 )
 
 func ExampleMarshal() {

--- a/ext.go
+++ b/ext.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 type extInfo struct {

--- a/ext_test.go
+++ b/ext_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vmihailenco/msgpack/v5"
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 func init() {

--- a/extra/msgpappengine/appengine.go
+++ b/extra/msgpappengine/appengine.go
@@ -3,7 +3,7 @@ package msgpappengine
 import (
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v6"
 	ds "google.golang.org/appengine/datastore"
 )
 

--- a/extra/msgpappengine/go.mod
+++ b/extra/msgpappengine/go.mod
@@ -2,9 +2,9 @@ module github.com/vmihailenco/msgpack/extra/appengine
 
 go 1.15
 
-replace github.com/vmihailenco/msgpack/v5 => ../..
+replace github.com/vmihailenco/msgpack/v6 => ../..
 
 require (
-	github.com/vmihailenco/msgpack/v5 v5.3.5
+	github.com/vmihailenco/msgpack/v6 v6.0.0
 	google.golang.org/appengine v1.6.7
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmihailenco/msgpack/v5
+module github.com/vmihailenco/msgpack/v6
 
 go 1.11
 

--- a/intern.go
+++ b/intern.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 const (

--- a/intern_test.go
+++ b/intern_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v6"
 )
 
 type NoIntern struct {

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v6"
 )
 
 type nameStruct struct {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "msgpack",
-  "version": "5.3.5"
+  "version": "6.0.0"
 }

--- a/time.go
+++ b/time.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 var timeExtID int8 = -1

--- a/types_test.go
+++ b/types_test.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vmihailenco/msgpack/v5"
-	"github.com/vmihailenco/msgpack/v5/msgpcode"
+	"github.com/vmihailenco/msgpack/v6"
+	"github.com/vmihailenco/msgpack/v6/msgpcode"
 )
 
 //------------------------------------------------------------------------------
@@ -249,9 +249,9 @@ var encoderTests = []encoderTest{
 	{[]byte{1, 2, 3}, "c403010203"},
 	{[3]byte{1, 2, 3}, "c403010203"},
 
-	{time.Unix(0, 0), "d6ff00000000"},
-	{time.Unix(1, 1), "d7ff0000000400000001"},
-	{time.Time{}, "c70cff00000000fffffff1886e0900"},
+	{time.Unix(0, 0), "c70fff010000000e7791f7000000000000b4"},
+	{time.Unix(1, 1), "c70fff010000000e7791f7010000000100b4"},
+	{time.Time{}, "c70fff01000000000000000000000000ffff"},
 
 	{IntSet{}, "90"},
 	{IntSet{8: struct{}{}}, "9108"},

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package msgpack
 
 // Version is the current release version.
 func Version() string {
-	return "5.3.5"
+	return "6.0.0"
 }


### PR DESCRIPTION
Change version with incompatible change of encoding/decoding of time.Time. In new version standard time.MarshalBinary and time.UnmarshalBinary are used. These changes are needed because of incorrect encoding time.Time value so decoded data have differences with original time (tested personally). Also current algorithm lose time location while encoding process

Second change is making the ErrArrayStruct error public for opportunity use errors.Is in project to separate the error from the others. It's useful in big projects with frequent releases which contain a lot of changes