### PR TITLE
Allow 1-2 byte strings in the dictionary

### DIFF
--- a/intern.go
+++ b/intern.go
@@ -57,18 +57,16 @@ func encodeInternedStringValue(e *Encoder, v reflect.Value) error {
 
 func (e *Encoder) encodeInternedString(s string, intern bool) error {
 	// Interned string takes at least 3 bytes. Plain string 1 byte + string len.
-	if len(s) >= minInternedStringLen {
-		if idx, ok := e.dict[s]; ok {
-			return e.encodeInternedStringIndex(idx)
-		}
+	if idx, ok := e.dict[s]; ok {
+		return e.encodeInternedStringIndex(idx)
+	}
 
-		if intern && len(e.dict) < maxDictLen {
-			if e.dict == nil {
-				e.dict = make(map[string]int)
-			}
-			idx := len(e.dict)
-			e.dict[s] = idx
+	if intern && len(s) >= minInternedStringLen && len(e.dict) < maxDictLen {
+		if e.dict == nil {
+			e.dict = make(map[string]int)
 		}
+		idx := len(e.dict)
+		e.dict[s] = idx
 	}
 
 	return e.encodeNormalString(s)


### PR DESCRIPTION
Interning 1-2 byte strings isn't very useful because their binary format is longer / equal to simply encoding it as a string. So we shouldn't try to automatically intern those strings.

However, if someone adds such string to their dict, they probably want it interned anyway. (In my case to reduce allocations.)

After this change, people explicitly passing a dict with 1-2 byte entries will see different binary output from msgpack. Decoding keeps working. Automatic interning is unchanged.