### PR TITLE
fix(reflect): not assignable to type

### DIFF
--- a/decode_value.go
+++ b/decode_value.go
@@ -128,7 +128,7 @@ func ptrValueDecoder(typ reflect.Type) decoderFunc {
 	return func(d *Decoder, v reflect.Value) error {
 		if d.hasNilCode() {
 			if !v.IsNil() {
-				v.Set(d.newValue(typ))
+				v.Set(reflect.Zero(v.Type()))
 			}
 			return d.DecodeNil()
 		}

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -528,3 +528,28 @@ func TestEncodeWrappedValue(t *testing.T) {
 	require.Nil(t, msgpack.NewEncoder(&buf).Encode(v))
 	require.Nil(t, msgpack.NewEncoder(&buf).Encode(c))
 }
+
+func TestPtrValueDecode(t *testing.T) {
+	type Foo struct {
+		Bar *int
+	}
+
+	b, err := msgpack.Marshal(Foo{})
+	require.Nil(t, err)
+
+	bar1 := 123
+	foo := Foo{Bar: &bar1}
+
+	err = msgpack.Unmarshal(b, &foo)
+	require.Nil(t, err)
+	require.Nil(t, foo.Bar)
+
+	bar2 := 456
+	b, err = msgpack.Marshal(Foo{Bar: &bar2})
+	require.Nil(t, err)
+
+	err = msgpack.Unmarshal(b, &foo)
+	require.Nil(t, err)
+	require.NotNil(t, foo.Bar)
+	require.Equal(t, *foo.Bar, bar2)
+}


### PR DESCRIPTION
Bug introduced in [this](https://github.com/vmihailenco/msgpack/commit/ac03b622aee87fabbb57e326eb29206a0c22a295#diff-4a1beffa0c21bcca199054c1196547dae379ae550f7d5f6def29ac4aed6d315fL130), which causes the panic:

```
--- FAIL: TestPtrValueDecode (0.00s)
panic: reflect.Set: value of type **int is not assignable to type *int [recovered]
	panic: reflect.Set: value of type **int is not assignable to type *int

goroutine 91 [running]:
testing.tRunner.func1.2({0x7775c0, 0xc0001fc990})
	/usr/local/go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1548 +0x397
panic({0x7775c0?, 0xc0001fc990?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
reflect.Value.assignTo({0x772ec0?, 0xc000044898?, 0xc000128901?}, {0x7edcc3, 0xb}, 0x76c860, 0x0)
	/usr/local/go/src/reflect/value.go:3307 +0x289
reflect.Value.Set({0x76c860?, 0xc000044848?, 0x76c860?}, {0x772ec0?, 0xc000044898?, 0xc000044838?})
	/usr/local/go/src/reflect/value.go:2260 +0xe6
github.com/vmihailenco/msgpack/v5.ptrValueDecoder.func1(0x79cbc0?, {0x76c860?, 0xc000044848?, 0xc000014b30?})
	/go/msgpack/decode_value.go:131 +0x127
github.com/vmihailenco/msgpack/v5.(*field).DecodeValue(0xc0001f1a80, 0xc000101980?, {0x79cbc0?, 0xc000044848?, 0x0?})
	/go/msgpack/types.go:119 +0x63
github.com/vmihailenco/msgpack/v5.(*Decoder).decodeStruct(0xc000163050, {0x79cbc0?, 0xc000044848?, 0x40f21a?}, 0x1)
	/go/msgpack/decode_map.go:341 +0x199
github.com/vmihailenco/msgpack/v5.decodeStructValue(0xc000163050, {0x79cbc0?, 0xc000044848?, 0x16?})
	/go/msgpack/decode_map.go:299 +0x1b0
github.com/vmihailenco/msgpack/v5.(*Decoder).DecodeValue(0x76b8a0?, {0x79cbc0?, 0xc000044848?, 0xc000500000?})
	/go/msgpack/decode.go:332 +0x7a
github.com/vmihailenco/msgpack/v5.(*Decoder).Decode(0xc000163050?, {0x76b8a0?, 0xc000044848?})
	/go/msgpack/decode.go:311 +0x772
github.com/vmihailenco/msgpack/v5.Unmarshal({0xc000128fc0, 0x6, 0x40}, {0x76b8a0, 0xc000044848})
	/go/msgpack/decode.go:60 +0x125
github.com/vmihailenco/msgpack/v5_test.TestPtrValueDecode(0xc0005036c0?)
	/go/msgpack/msgpack_test.go:543 +0xd8
testing.tRunner(0xc000503d40, 0x8206c0)
	/usr/local/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1648 +0x3ad
FAIL	github.com/vmihailenco/msgpack/v5	0.026s
FAIL
```