### PR TITLE
Allow encoding/decoding uint struct tag keys

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -175,6 +175,15 @@ func (d *Decoder) UsePreallocateValues(on bool) {
 	}
 }
 
+// UseUIntStructKeys enables support for decoding uint struct tag keys to their corresponding struct field.
+func (d *Decoder) UseUIntStructKeys(on bool) {
+	if on {
+		d.flags |= useUIntStructKeysFlag
+	} else {
+		d.flags &= ^useUIntStructKeysFlag
+	}
+}
+
 // DisableAllocLimit enables fully allocating slices/maps when the size is known
 func (d *Decoder) DisableAllocLimit(on bool) {
 	if on {

--- a/encode.go
+++ b/encode.go
@@ -17,6 +17,7 @@ const (
 	useCompactFloatsFlag
 	useInternedStringsFlag
 	omitEmptyFlag
+	useUIntStructKeysFlag
 )
 
 type writer interface {
@@ -193,6 +194,15 @@ func (e *Encoder) UseInternedStrings(on bool) {
 		e.flags |= useInternedStringsFlag
 	} else {
 		e.flags &= ^useInternedStringsFlag
+	}
+}
+
+// UseUIntStructKeys causes the Encoder to encode struct fields that have a valid uint tag key as uints.
+func (e *Encoder) UseUIntStructKeys(on bool) {
+	if on {
+		e.flags |= useUIntStructKeysFlag
+	} else {
+		e.flags &= ^useUIntStructKeysFlag
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -26,6 +26,41 @@ func ExampleMarshal() {
 	// Output: bar
 }
 
+func ExampleMarshal_intKeys() {
+	type Item struct {
+		Foo string `msgpack:"100"`
+		Bar string `msgpack:"200"`
+		Baz string `msgpack:"not_int_key"`
+	}
+
+	buf := new(bytes.Buffer)
+	enc := msgpack.NewEncoder(buf)
+	enc.UseUIntStructKeys(true)
+	err := enc.Encode(&Item{
+		Foo: "foo",
+		Bar: "bar",
+		Baz: "baz",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	var item Item
+	dec := msgpack.NewDecoder(buf)
+	dec.UseUIntStructKeys(true)
+	err = dec.Decode(&item)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(item.Foo)
+	fmt.Println(item.Bar)
+	fmt.Println(item.Baz)
+	// Output:
+	// foo
+	// bar
+	// baz
+}
+
 func ExampleMarshal_mapStringInterface() {
 	in := map[string]interface{}{"foo": 1, "hello": "world"}
 	b, err := msgpack.Marshal(in)

--- a/msgpcode/msgpcode.go
+++ b/msgpcode/msgpcode.go
@@ -86,3 +86,7 @@ func IsFixedExt(c byte) bool {
 func IsExt(c byte) bool {
 	return IsFixedExt(c) || c == Ext8 || c == Ext16 || c == Ext32
 }
+
+func IsUint(c byte) bool {
+	return c <= PosFixedNumHigh || c == Uint8 || c == Uint16 || c == Uint32 || c == Uint64
+}


### PR DESCRIPTION
This PR adds support for encoding/decoding structures like:
```
type Item struct {
	Field100 string `msgpack:"100"`
	Field200 string `msgpack:"200"`
	Foo string `msgpack:"not_int_key"`
}
```
where some of the msgpack keys are actually of type uint.

A new flag is exposed to control this behaviour:
```
buf := new(bytes.Buffer)
enc := msgpack.NewEncoder(buf)
enc.UseUIntStructKeys(true)
err := enc.Encode(&Item{
	Field100: "foo",
	Field200: "bar",
	Foo: "baz",
})
if err != nil {
	panic(err)
}

var Item item
dec := msgpack.NewDecoder(buf)
dec.UseUIntStructKeys(true)
err = dec.Decode(&item)
if err != nil {
	panic(err)
}
```

The reason I need this is because I have a device sending msgpack objects over usb that are encoded in this way (with uint keys).

I added an example to cover this use case.
I tried to add docs but couldn't find where the sources for https://msgpack.uptrace.dev/guide are.