### PR TITLE
Add option to prefer text unmarshaler when data type is String

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -24,6 +24,7 @@ const (
 	disallowUnknownFieldsFlag
 	usePreallocateValues
 	disableAllocLimitFlag
+	preferTextUnmarshalerForString
 )
 
 type bufReader interface {
@@ -181,6 +182,20 @@ func (d *Decoder) DisableAllocLimit(on bool) {
 		d.flags |= disableAllocLimitFlag
 	} else {
 		d.flags &= ^disableAllocLimitFlag
+	}
+}
+
+// PreferTextUnmarshalerForString makes the decoder prefer [encoding.TextUnmarshaler]
+// over [encoding.BinaryUnmarshaler] when both are implemented, and source
+// MessagePack data is a String (as opposed to Binary).
+//
+// If this option is not enabled, [encoding.BinaryUnmarshaler] will be preferred
+// instead, regardless of MessagePack data type.
+func (d *Decoder) PreferTextUnmarshalerForString(on bool) {
+	if on {
+		d.flags |= preferTextUnmarshalerForString
+	} else {
+		d.flags &= ^preferTextUnmarshalerForString
 	}
 }
 


### PR DESCRIPTION
This library currently always prefers to use `encoding.BinaryUnmashaler` when it's implemented by the target type.

This might lead to problems when the type also has a text representation implemented as `encoding.TextUnmarshaler`.

Consider `netip.Addr` from stdlib as example, which implements both. This library won't be able decode MessagePack containing a string `"192.0.2.1"` into `*netip.Addr` because it will attempt to use `encoding.BinaryUnmashaler` which doesn't expect text representation.

Fortunately, MessagePack has distinct string and binary types, so we can check the source data type before choosing the interface to use.

This commit changes the behaviour of decoder as follows. When

1) target Go data type implements both `BinaryUnmashaler` and
   `TextUnmarshaler`
2) source MessagePack data type is a string

`TextUnmarshaler` will be preferred over `BinaryUnmashaler`.

This feature is gated behind a `Decoder` option, because it is potentially backward-incompatible change.

See https://github.com/vmihailenco/msgpack/issues/370