### PR TITLE
"ignore struct length" flag

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -24,6 +24,7 @@ const (
 	disallowUnknownFieldsFlag
 	usePreallocateValues
 	disableAllocLimitFlag
+	ignoreStructLength
 )
 
 type bufReader interface {
@@ -181,6 +182,15 @@ func (d *Decoder) DisableAllocLimit(on bool) {
 		d.flags |= disableAllocLimitFlag
 	} else {
 		d.flags &= ^disableAllocLimitFlag
+	}
+}
+
+// IgnoreStructLength disables field count verification during parsing
+func (d *Decoder) IgnoreStructLength(on bool) {
+	if on {
+		d.flags |= ignoreStructLength
+	} else {
+		d.flags &= ^ignoreStructLength
 	}
 }
 

--- a/decode_map.go
+++ b/decode_map.go
@@ -311,14 +311,21 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 	}
 
 	fields := structs.Fields(v.Type(), d.structTag)
-	if n != len(fields.List) {
+	if d.flags&ignoreStructLength == 0 && n != len(fields.List) {
 		return errArrayStruct
 	}
 
 	for _, f := range fields.List {
+		n--
+		if n < 0 {
+			break
+		}
 		if err := f.DecodeValue(d, v); err != nil {
 			return err
 		}
+	}
+	if n > 0 {
+		d.skipNext(n)
 	}
 
 	return nil

--- a/types_test.go
+++ b/types_test.go
@@ -33,6 +33,12 @@ func (o *Object) UnmarshalMsgpack(b []byte) error {
 
 //------------------------------------------------------------------------------
 
+const (
+	ignoreStructLength uint32 = 1 << iota
+)
+
+//------------------------------------------------------------------------------
+
 type CustomTime time.Time
 
 func (t CustomTime) EncodeMsgpack(enc *msgpack.Encoder) error {
@@ -424,6 +430,7 @@ type typeTest struct {
 	out      interface{}
 	encErr   string
 	decErr   string
+	decFlags uint32
 	wantnil  bool
 	wantzero bool
 	wanted   interface{}
@@ -596,6 +603,18 @@ var (
 			out:    new(unexported),
 			decErr: "msgpack: number of fields in array-encoded struct has changed",
 		},
+		{
+			in:       OmitEmptyTest{"foo", "bar"},
+			out:      new(unexported),
+			wanted:   unexported{Foo: "foo"},
+			decFlags: ignoreStructLength,
+		},
+		{
+			in:       unexported{Foo: "foo"},
+			out:      new(OmitEmptyTest),
+			wanted:   OmitEmptyTest{"foo", ""},
+			decFlags: ignoreStructLength,
+		},
 
 		{in: (*EventTime)(nil), out: new(*EventTime)},
 		{in: &EventTime{time.Unix(0, 0)}, out: new(*EventTime)},
@@ -655,6 +674,9 @@ func TestTypes(t *testing.T) {
 		}
 
 		dec := msgpack.NewDecoder(&buf)
+		if test.decFlags&ignoreStructLength != 0 {
+			dec.IgnoreStructLength(true)
+		}
 		err = dec.Decode(test.out)
 		if test.decErr != "" {
 			test.requireErr(err, test.decErr)
@@ -702,6 +724,9 @@ func TestTypes(t *testing.T) {
 
 		var dst interface{}
 		dec := msgpack.NewDecoder(bytes.NewReader(b))
+		if test.decFlags&ignoreStructLength != 0 {
+			dec.IgnoreStructLength(true)
+		}
 		dec.SetMapDecoder(func(dec *msgpack.Decoder) (interface{}, error) {
 			return dec.DecodeUntypedMap()
 		})


### PR DESCRIPTION
In some scenarios, it is necessary to ignore the structure length.

One such example is [Tarantool](https://github.com/tarantool/tarantool). Due to the specifics of the Lua language, a structure that has an empty value at the end (for example, `{0, nil, 1, 2, nil}`) is truncated to the last non-nil value and becomes `{0, nil, 1, 2}`.

[More details are available in the Tarantool documentation](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_null/).

Despite this behavior, the official Go module [github.com/tarantool/go-tarantool/v2](https://github.com/tarantool/go-tarantool/tree/v2) still uses the `github.com/vmihailenco/msgpack` module in the decoder ([see here](https://github.com/tarantool/go-tarantool/blob/a2c8f8ed090801982ee6387c8ee227d00a8bb52c/decoder.go#L14)), which reports an error in such cases:  
`msgpack: number of fields in array-encoded struct has changed`.

This PR introduces an option to ignore this error and also fixes decoding when the number of fields differs from what is defined in the struct.