### PR TITLE
perf(decode): zero-alloc byte-slice reader for Unmarshal

### DIFF
--- a/byteslice_reader.go
+++ b/byteslice_reader.go
@@ -1,0 +1,46 @@
+package msgpack
+
+import (
+	"errors"
+	"io"
+)
+
+// byteSliceReader implements bufReader (io.Reader + io.ByteScanner) for
+// zero-allocation decoding from a []byte. When Unmarshal is called with
+// a complete byte slice, this avoids the overhead of bytes.NewReader +
+// bufio.NewReader (2 allocations + 4KB buffer + interface dispatch per byte).
+type byteSliceReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *byteSliceReader) reset(data []byte) {
+	r.data = data
+	r.pos = 0
+}
+
+func (r *byteSliceReader) ReadByte() (byte, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	c := r.data[r.pos]
+	r.pos++
+	return c, nil
+}
+
+func (r *byteSliceReader) UnreadByte() error {
+	if r.pos <= 0 {
+		return errors.New("msgpack: at beginning of input")
+	}
+	r.pos--
+	return nil
+}
+
+func (r *byteSliceReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}

--- a/decode.go
+++ b/decode.go
@@ -2,7 +2,6 @@ package msgpack
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -46,6 +45,10 @@ func GetDecoder() *Decoder {
 func PutDecoder(dec *Decoder) {
 	dec.r = nil
 	dec.s = nil
+	dec.bsr.data = nil
+	if dec.buf != nil {
+		dec.buf = dec.buf[:0]
+	}
 	decPool.Put(dec)
 }
 
@@ -56,7 +59,7 @@ func PutDecoder(dec *Decoder) {
 func Unmarshal(data []byte, v interface{}) error {
 	dec := GetDecoder()
 	dec.UsePreallocateValues(true)
-	dec.Reset(bytes.NewReader(data))
+	dec.ResetBytes(data)
 	err := dec.Decode(v)
 
 	PutDecoder(dec)
@@ -68,6 +71,7 @@ func Unmarshal(data []byte, v interface{}) error {
 type Decoder struct {
 	r          io.Reader
 	s          io.ByteScanner
+	bsr        byteSliceReader
 	mapDecoder func(*Decoder) (interface{}, error)
 	structTag  string
 	buf        []byte
@@ -124,6 +128,19 @@ func (d *Decoder) ResetReader(r io.Reader) {
 		d.r = br
 		d.s = br
 	}
+}
+
+// ResetBytes is like Reset but optimized for decoding from a byte slice.
+// It avoids allocating bytes.NewReader and bufio.NewReader by using an
+// embedded byte-slice reader with zero-copy sub-slicing.
+func (d *Decoder) ResetBytes(data []byte) {
+	d.bsr.reset(data)
+	d.r = &d.bsr
+	d.s = &d.bsr
+	d.mapDecoder = nil
+	d.flags = 0
+	d.structTag = ""
+	d.dict = nil
 }
 
 func (d *Decoder) SetMapDecoder(fn func(*Decoder) (interface{}, error)) {
@@ -194,6 +211,11 @@ func (d *Decoder) Buffered() io.Reader {
 func (d *Decoder) Decode(v interface{}) error {
 	var err error
 	switch v := v.(type) {
+	case *interface{}:
+		if v != nil && *v == nil {
+			*v, err = d.decodeInterfaceCond()
+			return err
+		}
 	case *string:
 		if v != nil {
 			*v, err = d.DecodeString()
@@ -625,6 +647,19 @@ func (d *Decoder) readFull(b []byte) error {
 }
 
 func (d *Decoder) readN(n int) ([]byte, error) {
+	// Fast path: byte-slice reader — zero-copy sub-slice of input buffer.
+	if d.bsr.data != nil {
+		if d.bsr.pos+n > len(d.bsr.data) {
+			return nil, io.ErrUnexpectedEOF
+		}
+		b := d.bsr.data[d.bsr.pos : d.bsr.pos+n]
+		d.bsr.pos += n
+		if d.rec != nil {
+			d.rec = append(d.rec, b...)
+		}
+		return b, nil
+	}
+
 	var err error
 	if d.flags&disableAllocLimitFlag != 0 {
 		d.buf, err = readN(d.r, d.buf, n)
@@ -635,7 +670,6 @@ func (d *Decoder) readN(n int) ([]byte, error) {
 		return nil, err
 	}
 	if d.rec != nil {
-		// TODO: read directly into d.rec?
 		d.rec = append(d.rec, d.buf...)
 	}
 	return d.buf, nil


### PR DESCRIPTION
Replace bytes.NewReader + bufio.NewReader in Unmarshal() with an embedded byteSliceReader that uses index-cursor access into the original []byte. This eliminates 2 allocations (reader + 4KB bufio buffer) per call.

Additionally:
- Add *interface{} fast path in Decode() to bypass reflect overhead for the common Unmarshal(data, &interface{}) pattern
- Add zero-copy readN() fast path that returns sub-slices of input
- Preserve buf capacity across pool returns in PutDecoder()

benchstat (5 runs, Apple M3 Max):
  StructUnmarshal:          -21% time, -50% mem (96→48 B/op), -1 alloc
  StructUnmarshalPartially: -33% time, -75% mem (64→16 B/op), -1 alloc
  StructVmihailencoMsgpack: -11% time, -3% mem, -1 alloc
  StructManual:             -10% time, -3% mem, -1 alloc